### PR TITLE
Spin up WP sites with the plugin on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/test/site/

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,0 +1,8 @@
+name: wordpress-classic-editor
+recipe: wordpress
+config:
+  webroot: test/site/
+  php: '7.0'
+tooling:
+  bash:
+    service: appserver

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ php:
 
 env:
   - WP_VERSION=4.9.7 PHP_VERSION=7.0
-  - WP_VERSION=4.9.8 PHP_VERSION=5.3
-  - WP_VERSION=5.0-beta1 WP_LOCALE=es_ES PHP_VERSION=5.6
+  - WP_VERSION=4.9.8 WP_LOCALE=es_ES PHP_VERSION=5.3
+  - WP_VERSION=5.0-beta1 PHP_VERSION=5.6
   - WP_VERSION=5.0-beta2 PHP_VERSION=7.2
 
 # https://docs.devwithlando.io/tutorials/lando-and-ci.html#lando-ify-your-travisyml

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - WP_VERSION=4.9.8 WP_LOCALE=es_ES PHP_VERSION=5.3
   - WP_VERSION=5.0-beta1 PHP_VERSION=5.6
   - WP_VERSION=5.0-beta2 PHP_VERSION=7.2
-  - WP_VERSION=nightly PHP_VERSION=7.2
+  - WP_VERSION=5.0-nightly PHP_VERSION=7.2
 
 # https://docs.devwithlando.io/tutorials/lando-and-ci.html#lando-ify-your-travisyml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   - WP_VERSION=4.9.8 WP_LOCALE=es_ES PHP_VERSION=5.3
   - WP_VERSION=5.0-beta1 PHP_VERSION=5.6
   - WP_VERSION=5.0-beta2 PHP_VERSION=7.2
+  - WP_VERSION=nightly PHP_VERSION=7.2
 
 # https://docs.devwithlando.io/tutorials/lando-and-ci.html#lando-ify-your-travisyml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+sudo: required
+dist: trusty
+
+# this section doesn't matter because services are managed using lando
+language: php
+php:
+  - '7.0'
+
+env:
+  - WP_VERSION=4.9.7 PHP_VERSION=7.0
+  - WP_VERSION=4.9.8 PHP_VERSION=5.3
+  - WP_VERSION=5.0-beta1 WP_LOCALE=es_ES PHP_VERSION=5.6
+  - WP_VERSION=5.0-beta2 PHP_VERSION=7.2
+
+# https://docs.devwithlando.io/tutorials/lando-and-ci.html#lando-ify-your-travisyml
+
+services:
+  - docker
+
+before_install:
+  - sudo apt-get -y update
+  - sudo apt-get -y install cgroup-bin curl
+  - curl -L -o /tmp/lando-latest.deb https://github.com/lando/lando/releases/download/v3.0.0-rc.1/lando-v3.0.0-rc.1.deb
+  - sudo dpkg -i /tmp/lando-latest.deb
+  - lando version
+  - ./test/lando-setup.sh
+
+script:
+  - true

--- a/test/copy-plugin.sh
+++ b/test/copy-plugin.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# exit on error
+set -e
+
+cd "$(dirname "$0")"
+cd ..
+
+rm -rf test/site/wp-content/plugins/classic-editor/
+mkdir -p test/site/wp-content/plugins/classic-editor/
+cp -var *.php js/ css/ \
+    test/site/wp-content/plugins/classic-editor/

--- a/test/install-wp-cli.sh
+++ b/test/install-wp-cli.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# This is a workaround for the following issue:
+# https://github.com/lando/lando/issues/1197#issuecomment-429733044
+
+mkdir -p /var/www/.composer/vendor/bin
+
+# TODO: Is $PHP_VERSION always e.g. 5.3.29 at this point, or can it also be
+# just 5.3?
+PHP_VERSION="$PHP_VERSION.0"
+
+if [[ "$PHP_VERSION" = 5.[23].* ]]; then
+	# WP-CLI 2.x not supported
+	wget \
+		https://github.com/wp-cli/wp-cli/releases/download/v1.5.0/wp-cli-1.5.0.phar \
+		-O /var/www/.composer/vendor/bin/wp
+else
+	wget \
+		https://github.com/wp-cli/wp-cli/releases/download/v2.0.1/wp-cli-2.0.1.phar \
+		-O /var/www/.composer/vendor/bin/wp
+fi
+chmod +x /var/www/.composer/vendor/bin/wp
+wp --version
+exit $?

--- a/test/lando-setup.sh
+++ b/test/lando-setup.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# exit on error
+set -e
+
+WP_VERSION="${WP_VERSION:-4.9.7}"
+WP_LOCALE="${WP_LOCALE:-en_US}"
+PHP_VERSION="${PHP_VERSION:-7.0}"
+
+cd "$(dirname "$0")"
+cd ..
+
+# Hack - awaiting https://github.com/lando/lando/pull/750
+perl -pi -we "s/^  php: .*/  php: '$PHP_VERSION'/" .lando.yml
+
+lando start -v
+lando wp --version || lando bash test/install-wp-cli.sh
+rm -rf test/site/[a-z]*
+lando wp core download \
+    --path=test/site/ \
+    --version=$WP_VERSION \
+    --locale=$WP_LOCALE
+
+lando wp config create \
+    --path=test/site/ \
+    --dbname=wordpress \
+    --dbuser=wordpress \
+    --dbpass=wordpress \
+    --dbhost=database
+
+lando wp config set \
+    --path=test/site/ \
+    --type=constant \
+    --raw \
+    WP_AUTO_UPDATE_CORE false
+
+lando wp config set \
+    --path=test/site/ \
+    --type=constant \
+    --raw \
+    WP_DEBUG true
+
+wp_url="$(lando info | grep -A2 '"urls": \[$' | tail -n 1 | cut -d'"' -f2)"
+lando wp core install \
+    --path=test/site/ \
+    --url="$wp_url" \
+    '--title="My Test Site"' \
+    --admin_user="admin" \
+    --admin_password="admin" \
+    --admin_email="admin@example.com" \
+    --skip-email
+
+echo "Testing site URL: $wp_url"
+
+./test/copy-plugin.sh
+
+lando wp plugin activate \
+    --path=test/site/ \
+    classic-editor
+
+echo
+echo "Test site is ACTIVE: $wp_url"
+echo "username: admin"
+echo "password: admin"

--- a/test/lando-setup.sh
+++ b/test/lando-setup.sh
@@ -15,11 +15,22 @@ perl -pi -we "s/^  php: .*/  php: '$PHP_VERSION'/" .lando.yml
 
 lando start -v
 lando wp --version || lando bash test/install-wp-cli.sh
-rm -rf test/site/[a-z]*
-lando wp core download \
-    --path=test/site/ \
-    --version=$WP_VERSION \
-    --locale=$WP_LOCALE
+rm -rf test/site/ test/wordpress/
+
+if [ "$WP_VERSION" = "5.0-nightly" ]; then
+    wget https://wordpress.org/nightly-builds/wordpress-5.0-latest.zip \
+        -O test/wordpress-5.0-latest.zip
+    unzip -q test/wordpress-5.0-latest.zip -d test/ # creates './test/wordpress/' dir
+    mv test/wordpress/ test/site/
+    rm test/wordpress-5.0-latest.zip # clean up after ourselves
+    echo -n 'extracted WP 5.0-nightly: '
+    grep '^\$wp_version' test/site/wp-includes/version.php
+else
+    lando wp core download \
+        --path=test/site/ \
+        --version=$WP_VERSION \
+        --locale=$WP_LOCALE
+fi
 
 lando wp config create \
     --path=test/site/ \

--- a/test/lando-setup.sh
+++ b/test/lando-setup.sh
@@ -52,6 +52,7 @@ lando wp config set \
     WP_DEBUG true
 
 wp_url="$(lando info | grep -A2 '"urls": \[$' | tail -n 1 | cut -d'"' -f2)"
+lando wp db reset --path=test/site/ --yes
 lando wp core install \
     --path=test/site/ \
     --url="$wp_url" \

--- a/test/lando-tail-logs.sh
+++ b/test/lando-tail-logs.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Watch the webserver's `error_log` file inside the lando container, and clean
+# up a bunch of noise in the output.
+
+lando logs appserver_1 -f | perl -nwe '
+	# no buffering
+	select(STDOUT); $| = 1;
+
+	# add colors, but only if stdout is a terminal
+	my $acc_begin = "";
+	my $err_begin = "";
+	my $end = "";
+	-t 1 and $acc_begin = "\e[0;32m"; # green
+	-t 1 and $err_begin = "\e[1;35m"; # purple
+	-t 1 and $end = "\e[0m"; # reset
+
+	# get rid of appserver_1 prefix + ANSI codes
+	s/^.{0,8}appserver_1\s+\|.{0,8}\s+//;
+
+	if (/\[:error\]/) {
+		# clean up error log entry
+		# get rid of unneeded markers
+		s/\[:error\] \[pid \d+\] \[client [^]]+\] //;
+
+		# keep and maybe colorize time, remove date and microseconds
+		s/^\[... ... \d\d /${err_begin}E /;
+		s/\d\d\d 20\d\d\]/${end}/;
+
+		# remove "referer"
+		s/, referer: h\S+$//;
+
+		print;
+
+	} elsif (/^[\d.]+ - -/) {
+		# clean up access log entry
+		s/^/${acc_begin}A /;
+		s/ - - \[.*20\d\d:/ /;
+		s/ [\d+-]+\]/${end}/;
+
+		# TODO: ignored (not printed)
+	}
+'


### PR DESCRIPTION
This PR adds automated WP site creation for multiple PHP and WP versions, using [lando](https://github.com/lando/lando), a tool that wraps `docker` and `docker-compose`.

This works on Travis CI and locally, as long as you [install docker-ce](https://docs.docker.com/install/linux/docker-ce/debian/#set-up-the-repository) and [install lando](https://docs.devwithlando.io/installation/installing.html).

PHP 5.2 is not supported without some extra work:  https://github.com/lando/lando/issues/1256

This is the first step towards a decent automated test matrix for this plugin.  The next steps could be something like this:

- On WP 4.9.x, install various versions of the Gutenberg plugin
- Install a tool like [puppeteer](https://github.com/GoogleChrome/puppeteer) and use it to run through some testing scenarios that verify editor controls with various settings of the plugin
- These tests could use raw Node.js scripts (probably a script that runs the major test cases in order for each WP/PHP version), or a testing framework like [mocha](https://github.com/mochajs/mocha).
- Make Travis cache the Docker images involved in this build.  More info: https://github.com/lando/lando/issues/1248