### PR TITLE
Maintain the Privacy Policy help notice location

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -77,10 +77,6 @@ function classic_editor_init_actions() {
 
 		// lib/compat.php
 		remove_filter( 'wp_refresh_nonces', 'gutenberg_add_rest_nonce_to_heartbeat_response_headers' );
-		// Move the Privacy Policy help notice back under the title field.
-		remove_action( 'admin_notices', 'gutenberg_show_privacy_policy_help_text' );
-		remove_action( 'admin_notices', array( 'WP_Privacy_Policy_Content', 'notice' ) );
-		add_action( 'edit_form_after_title', array( 'WP_Privacy_Policy_Content', 'notice' ) );
 
 		// lib/rest-api.php
 		remove_action( 'rest_api_init', 'gutenberg_register_rest_routes' );
@@ -174,6 +170,11 @@ function classic_editor_admin_init() {
 	) );
 
 	add_settings_field( 'classic-editor', __( 'Classic editor settings', 'classic-editor' ), 'classic_editor_settings', 'writing' );
+
+	// Move the Privacy Policy help notice back under the title field.
+	remove_action( 'admin_notices', 'gutenberg_show_privacy_policy_help_text' );
+	remove_action( 'admin_notices', array( 'WP_Privacy_Policy_Content', 'notice' ) );
+	add_action( 'edit_form_after_title', array( 'WP_Privacy_Policy_Content', 'notice' ) );
 }
 
 /**

--- a/classic-editor.php
+++ b/classic-editor.php
@@ -77,6 +77,10 @@ function classic_editor_init_actions() {
 
 		// lib/compat.php
 		remove_filter( 'wp_refresh_nonces', 'gutenberg_add_rest_nonce_to_heartbeat_response_headers' );
+		// Move the Privacy Policy help notice back under the title field.
+		remove_action( 'admin_notices', 'gutenberg_show_privacy_policy_help_text' );
+		remove_action( 'admin_notices', array( 'WP_Privacy_Policy_Content', 'notice' ) );
+		add_action( 'edit_form_after_title', array( 'WP_Privacy_Policy_Content', 'notice' ) );
 
 		// lib/rest-api.php
 		remove_action( 'rest_api_init', 'gutenberg_register_rest_routes' );


### PR DESCRIPTION
When using the classic editor, the Privacy Policy help notice location in 4.9.x (directly under the post title with the `edit_form_after_title` action hook) should be maintained.

Related: [WordPress/gutenberg#11999](https://github.com/WordPress/gutenberg/pull/11999/), [WordPress/gutenberg#11604](https://github.com/WordPress/gutenberg/pull/11604), [Trac-45057](https://core.trac.wordpress.org/ticket/45057).