### PR TITLE
Tweaked Build 2018-12-02

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -41,10 +41,6 @@ defined( 'ABSPATH' ) || die( 'Invalid request.' ); # TWEAK: alternative code mor
 
 if ( ! defined( 'PLUGIN_CLASSIC_EDITOR_BUILD' ) ) define( 'PLUGIN_CLASSIC_EDITOR_BUILD', '2018-12-02' );
 
- //if ( ! defined( 'ABSPATH' ) ) {
-//	die( 'Invalid request.' );
-//}
-
 	add_filter( 'plugin_row_meta', 'classic_editor_adds_row_meta_build', 10, 4 ); # TWEAK: only for development version?
 
 	/**
@@ -58,6 +54,10 @@ if ( ! defined( 'PLUGIN_CLASSIC_EDITOR_BUILD' ) ) define( 'PLUGIN_CLASSIC_EDITOR
 			}
 		return $plugin_meta;
 	}
+
+ //if ( ! defined( 'ABSPATH' ) ) {
+//	die( 'Invalid request.' );
+//}
 
 if ( ! class_exists( 'Classic_Editor' ) ) :
 class Classic_Editor {
@@ -268,7 +268,6 @@ class Classic_Editor {
 		add_settings_field( 'classic-editor-1', $heading_1, array( __CLASS__, 'settings_1' ), 'writing' );
 
 		// See https://github.com/WordPress/classic-editor/issues/15
-
 		// add_settings_field( 'classic-editor-2', $heading_2, array( __CLASS__, 'settings_2' ), 'writing' );
 
 		add_settings_field( 'classic-editor-3', $heading_3, array( __CLASS__, 'settings_3' ), 'writing' );
@@ -360,7 +359,6 @@ class Classic_Editor {
 
 	public static function settings_2() {
 		$settings = self::get_settings();
-
 		$padding = is_rtl() ? 'padding-left: 1em;' : 'padding-right: 1em;';
 
 		?>
@@ -705,6 +703,7 @@ class Classic_Editor {
 
 		return $post_states;
 	}
+
 	public static function on_admin_init() {
 		global $pagenow;
 
@@ -734,18 +733,18 @@ class Classic_Editor {
 	}
 
 	/**
-	 * Delete the options on deactivation. # TWEAK: prevents plugin updates or simply deactivating (but not deleting or uninstalling) losing custom user-defined settings
+	 * Delete the options on deactivation.
 	 */
-	public static function deactivate() {
+	public static function deactivate() {               # TWEAK: prevents plugin updates or simply deactivating (but not deleting or uninstalling) losing custom user-defined settings
 //		delete_option( 'classic-editor-replace' );
 //		delete_option( 'classic-editor-remember' );
 //		delete_option( 'classic-editor-allow-users' );
 	}
 
 	/**
-	 * Delete the options on uninstallation.  # TWEAK: removes custom user defined settings only when plugin is deleted or uninstalled
+	 * Delete the options on uninstallation.
 	 */
-	public static function uninstall() {
+	public static function uninstall() {                # TWEAK: removes custom user defined settings only when plugin is deleted or uninstalled
 		delete_option( 'classic-editor-replace' );
 		delete_option( 'classic-editor-remember' );
 		delete_option( 'classic-editor-allow-users' );

--- a/classic-editor.php
+++ b/classic-editor.php
@@ -83,8 +83,8 @@ class Classic_Editor {
 			// TODO: needs https://github.com/WordPress/gutenberg/pull/12309
 			// add_action( 'enqueue_block_editor_assets', array( __CLASS__, 'enqueue_scripts' ) );
 
-			if ( $settings['remember'] ) {
-				add_action( 'edit_form_top', array( __CLASS__, 'remember_classic' ) );
+			if ( $settings['allow-users'] ) {
+				add_action( 'edit_form_top', array( __CLASS__, 'remember_classic_editor' ) );
 				add_filter( 'block_editor_settings', array( __CLASS__, 'remember_block_editor' ), 10, 2 );
 				add_filter( 'display_post_states', array( __CLASS__, 'add_post_state' ), 10, 2 );
 			}
@@ -95,10 +95,9 @@ class Classic_Editor {
 		/**
 		 * Can be used to override the plugin's settings and hide the settings UI.
 		 *
-		 * Has to return an associative array with three keys.
+		 * Has to return an associative array with two keys.
 		 * The defaults are:
 		 *   'editor' => 'classic', // Accepted values: 'classic', 'block'.
-		 *   'remember' => false,
 		 *   'allow_users' => true,
 		 *
 		 * Note: using this filter always hides the settings UI (as it overrides the user's choices).
@@ -106,16 +105,8 @@ class Classic_Editor {
 		$settings = apply_filters( 'classic_editor_plugin_settings', false );
 
 		if ( is_array( $settings ) ) {
-			// Normalize...
-			$editor = 'classic';
-
-			if ( isset( $settings['editor'] ) && $settings['editor'] === 'block' ) {
-				$editor = 'block';
-			}
-
 			return array(
-				'editor' => $editor,
-				'remember' => ( ! empty( $settings['remember'] ) ),
+				'editor' => ( isset( $settings['editor'] ) && $settings['editor'] === 'block' ) ? 'block' : 'classic',
 				'allow-users' => ( ! isset( $settings['allow-users'] ) || $settings['allow-users'] ), // Allow by default.
 				'hide-settings-ui' => true,
 			);
@@ -126,14 +117,13 @@ class Classic_Editor {
 		}
 
 		$allow_users = ( get_option( 'classic-editor-allow-users' ) !== 'disallow' );
-		$remember = ( get_option( 'classic-editor-remember' ) === 'remember' );
 		$option = get_option( 'classic-editor-replace' );
 
 		// Normalize old options.
 		if ( $option === 'block' || $option === 'no-replace' ) {
 			$editor = 'block';
 		} else {
-			// `empty( $option ) || $option === 'classic' || $option === 'replace'`.
+			// empty( $option ) || $option === 'classic' || $option === 'replace'.
 			$editor = 'classic';
 		}
 
@@ -141,23 +131,13 @@ class Classic_Editor {
 		if ( ( ! isset( $GLOBALS['pagenow'] ) || $GLOBALS['pagenow'] !== 'options-writing.php' ) && $allow_users ) {
 			$user_options = get_user_option( 'classic-editor-settings' );
 
-			if ( is_array( $user_options ) ) {
-				if ( isset( $user_options['remember'] ) ) {
-					$remember = $user_options['remember'] === 'remember';
-				}
-
-				if ( isset( $user_options['editor'] ) && ( $user_options['editor'] === 'block' || $user_options['editor'] === 'classic' ) ) {
-					$editor = $user_options['editor'];
-				}
+			if ( $user_options === 'block' || $user_options === 'classic' ) {
+				$editor = $user_options;
 			}
 		}
 
-		// See https://github.com/WordPress/classic-editor/issues/15
-		$remember = true;
-
 		self::$settings = array(
 			'editor' => $editor,
-			'remember' => $remember,
 			'hide-settings-ui' => false,
 			'allow-users' => $allow_users,
 		);
@@ -173,7 +153,7 @@ class Classic_Editor {
 		if ( $post_id ) {
 			$settings = self::get_settings();
 
-			if ( $settings['remember'] && ! isset( $_GET['classic-editor__forget'] ) ) {
+			if ( $settings['allow-users'] && ! isset( $_GET['classic-editor__forget'] ) ) {
 				$which = get_post_meta( $post_id, 'classic-editor-rememebr', true );
 
 				// The editor choice will be "remembered" when the post is opened in either Classic or Block editor.
@@ -215,28 +195,19 @@ class Classic_Editor {
 			'sanitize_callback' => array( __CLASS__, 'validate_option_editor' ),
 		) );
 
-		register_setting( 'writing', 'classic-editor-remember', array(
-			'sanitize_callback' => array( __CLASS__, 'validate_option_remember' ),
-		) );
-
 		register_setting( 'writing', 'classic-editor-allow-users', array(
 			'sanitize_callback' => array( __CLASS__, 'validate_option_allow_users' ),
 		) );
 
 		add_option_whitelist( array(
-			'writing' => array( 'classic-editor-replace', 'classic-editor-remember', 'classic-editor-allow-users' ),
+			'writing' => array( 'classic-editor-replace', 'classic-editor-allow-users' ),
 		) );
 
 		$heading_1 = __( 'Default editor for all users', 'classic-editor' );
-		$heading_2 = __( 'Open the last editor used for each post', 'classic-editor' );
-		$heading_3 = __( 'Allow users to switch editors', 'classic-editor' );
+		$heading_2 = __( 'Allow users to switch editors', 'classic-editor' );
 
 		add_settings_field( 'classic-editor-1', $heading_1, array( __CLASS__, 'settings_1' ), 'writing' );
-
-		// See https://github.com/WordPress/classic-editor/issues/15
-		// add_settings_field( 'classic-editor-2', $heading_2, array( __CLASS__, 'settings_2' ), 'writing' );
-
-		add_settings_field( 'classic-editor-3', $heading_3, array( __CLASS__, 'settings_3' ), 'writing' );
+		add_settings_field( 'classic-editor-2', $heading_2, array( __CLASS__, 'settings_2' ), 'writing' );
 	}
 
 	public static function save_user_settings( $user_id ) {
@@ -252,14 +223,7 @@ class Classic_Editor {
 			}
 
 			$editor = self::validate_option_editor( $_POST['classic-editor-replace'] );
-			$remember = self::validate_option_remember( $_POST['classic-editor-remember'] );
-
-			$options = array(
-				'editor' => $editor,
-				'remember' => $remember,
-			);
-
-			update_user_option( $user_id, 'classic-editor-settings', $options );
+			update_user_option( $user_id, 'classic-editor-settings', $editor );
 		}
 	}
 
@@ -272,14 +236,6 @@ class Classic_Editor {
 		}
 
 		return 'classic';
-	}
-
-	public static function validate_option_remember( $value ) {
-		if ( $value === 'remember' ) {
-			return 'remember';
-		}
-
-		return 'no-remember';
 	}
 
 	public static function validate_option_allow_users( $value ) {
@@ -324,25 +280,6 @@ class Classic_Editor {
 	}
 
 	public static function settings_2() {
-		$settings = self::get_settings();
-		$padding = is_rtl() ? 'padding-left: 1em;' : 'padding-right: 1em;';
-
-		?>
-		<div class="classic-editor-options">
-			<label style="<?php echo $padding ?>">
-			<input type="radio" name="classic-editor-remember" value="remember"<?php if ( $settings['remember'] ) echo ' checked'; ?> />
-			<?php _e( 'Yes', 'classic-editor' ); ?>
-			</label>
-
-			<label style="<?php echo $padding ?>">
-			<input type="radio" name="classic-editor-remember" value="no-remember"<?php if ( ! $settings['remember'] ) echo ' checked'; ?> />
-			<?php _e( 'No', 'classic-editor' ); ?>
-			</label>
-		</div>
-		<?php
-	}
-
-	public static function settings_3() {
 		$settings = self::get_settings( 'refresh' );
 		$padding = is_rtl() ? 'padding-left: 1em;' : 'padding-right: 1em;';
 
@@ -386,15 +323,6 @@ class Classic_Editor {
 				<?php self::settings_1(); ?>
 				</td>
 			</tr>
-			<?php // See https://github.com/WordPress/classic-editor/issues/15 ?>
-			<?php if ( false ) : ?>
-			<tr>
-				<th scope="row"><?php _e( 'Open the last editor used for each post', 'classic-editor' ); ?></th>
-				<td>
-				<?php self::settings_2(); ?>
-				</td>
-			</tr>
-			<?php endif; ?>
 		</table>
 		<?php
 	}
@@ -436,7 +364,7 @@ class Classic_Editor {
 	/**
 	 * Remember when the Classic Editor was used to edit a post.
 	 */
-	public static function remember_classic( $post ) {
+	public static function remember_classic_editor( $post ) {
 		if ( ! empty( $post->ID ) ) {
 			self::remember( $post->ID, 'classic-editor' );
 		}
@@ -530,7 +458,7 @@ class Classic_Editor {
 
 		$edit_url = remove_query_arg( 'classic-editor', $edit_url );
 
-		if ( $settings['remember'] ) {
+		if ( $settings['allow-users'] ) {
 			// Forget the previous value when going to a specific editor.
 			$edit_url = add_query_arg( 'classic-editor__forget', '', $edit_url );
 		}
@@ -613,7 +541,7 @@ class Classic_Editor {
 
 		$settings = self::get_settings();
 
-		if ( $settings['remember'] ) {
+		if ( $settings['allow-users'] ) {
 			// Forget the previous value when going to a specific editor.
 			$edit_url = add_query_arg( 'classic-editor__forget', '', $edit_url );
 		}
@@ -653,7 +581,7 @@ class Classic_Editor {
 	public static function add_post_state( $post_states, $post ) {
 		$settings = self::get_settings();
 
-		if ( ! $settings['remember'] ) {
+		if ( ! $settings['allow-users'] ) {
 			return $post_states;
 		}
 
@@ -693,7 +621,6 @@ class Classic_Editor {
 	public static function activate() {
 		if ( ! get_option( 'classic-editor-replace' ) ) {
 			update_option( 'classic-editor-replace', 'classic' );
-			update_option( 'classic-editor-remember', '' );
 			update_option( 'classic-editor-allow-users', 'allow' );
 		}
 	}
@@ -703,7 +630,6 @@ class Classic_Editor {
 	 */
 	public static function uninstall() {
 		delete_option( 'classic-editor-replace' );
-		delete_option( 'classic-editor-remember' );
 		delete_option( 'classic-editor-allow-users' );
 	}
 }

--- a/classic-editor.php
+++ b/classic-editor.php
@@ -3,8 +3,8 @@
  * Classic Editor
  *
  * Plugin Name: Classic Editor
- * Plugin URI:  https://wordpress.org
- * Description: Enables the WordPress classic editor and the old-style Edit Post screen with TinyMCE, meta boxes, etc. Supports the older plugins that extend this screen.
+ * Plugin URI:  https://wordpress.org/plugins/classic-editor/
+ * Description: Enables the WordPress classic editor and the old-style Edit Post screen with TinyMCE, Meta Boxes, etc. Supports the older plugins that extend this screen.
  * Version:     1.0-beta
  * Author:      WordPress Contributors
  * Author URI:  https://github.com/WordPress/classic-editor/
@@ -37,8 +37,7 @@ class Classic_Editor {
 		$supported_wp_version = version_compare( $GLOBALS['wp_version'], '5.0-beta', '>' );
 
 		register_activation_hook( __FILE__, array( __CLASS__, 'activate' ) );
-		register_deactivation_hook( __FILE__, array( __CLASS__, 'deactivate' ) );
-		register_uninstall_hook( __FILE__, array( __CLASS__, 'uninstall' ) ); # TWEAK: preserve cutom user settings when plugin is updated or deactivated but not deleted
+		register_uninstall_hook( __FILE__, array( __CLASS__, 'uninstall' ) );
 
 		// Show warning on the "What's New" screen (about.php).
 		add_action( 'all_admin_notices', array( __CLASS__, 'notice_after_upgrade' ) );
@@ -127,7 +126,7 @@ class Classic_Editor {
 			return self::$settings;
 		}
 
-		$allow_users = ( get_option( 'classic-editor-allow-users' ) === 'allow' );
+		$allow_users = ( get_option( 'classic-editor-allow-users' ) !== 'disallow' );
 		$remember = ( get_option( 'classic-editor-remember' ) === 'remember' );
 		$option = get_option( 'classic-editor-replace' );
 
@@ -701,18 +700,9 @@ class Classic_Editor {
 	}
 
 	/**
-	 * Delete the options on deactivation.
+	 * Delete the options on uninstall.
 	 */
-	public static function deactivate() {               # TWEAK: prevents plugin updates or simply deactivating (but not deleting or uninstalling) losing custom user-defined settings
-//		delete_option( 'classic-editor-replace' );
-//		delete_option( 'classic-editor-remember' );
-//		delete_option( 'classic-editor-allow-users' );
-	}
-
-	/**
-	 * Delete the options on uninstallation.
-	 */
-	public static function uninstall() {                # TWEAK: removes custom user defined settings only when plugin is deleted or uninstalled
+	public static function uninstall() {
 		delete_option( 'classic-editor-replace' );
 		delete_option( 'classic-editor-remember' );
 		delete_option( 'classic-editor-allow-users' );

--- a/classic-editor.php
+++ b/classic-editor.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Classic Editor
  *
@@ -12,7 +12,6 @@
  * License URI: http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  * Text Domain: classic-editor
  * Domain Path: /languages
- * Network:     true
  *
  * This program is free software; you can redistribute it and/or modify it under the terms of the GNU
  * General Public License version 2, as published by the Free Software Foundation. You may NOT assume
@@ -295,7 +294,7 @@ class Classic_Editor {
 		$settings = self::get_settings( 'refresh' );
 
 		if ( defined( 'IS_PROFILE_PAGE' ) && IS_PROFILE_PAGE ) {
-			$label = __( 'Select Editor.', 'classic-editor' );
+			$label = __( 'Select editor.', 'classic-editor' );
 		} else {
 			$label = __( 'Select default editor for all users.', 'classic-editor' );
 		}
@@ -390,7 +389,7 @@ class Classic_Editor {
 			<?php // See https://github.com/WordPress/classic-editor/issues/15 ?>
 			<?php if ( false ) : ?>
 			<tr>
-				<th scope="row"><?php _e( 'Open the last editor used', 'classic-editor' ); ?></th>  <!-- Remove redundant words to maintain description in the same line -- (for each post) -->
+				<th scope="row"><?php _e( 'Open the last editor used for each post', 'classic-editor' ); ?></th>
 				<td>
 				<?php self::settings_2(); ?>
 				</td>
@@ -538,7 +537,7 @@ class Classic_Editor {
 
 		?>
 		<p>
-			<label class="screen-reader-text" for="classic-editor-switch-editor"><?php _e( 'Select Editor' ); ?></label>
+			<label class="screen-reader-text" for="classic-editor-switch-editor"><?php _e( 'Select editor' ); ?></label>
 			<select id="classic-editor-switch-editor" style="width: 100%;max-width: 20em;">
 				<option value=""><?php _e( 'Classic Editor', 'classic-editor' ); ?></option>
 				<option value="" data-url="<?php echo esc_url( $edit_url ); ?>"><?php _e( 'Block Editor', 'classic-editor' ); ?></option>


### PR DESCRIPTION
- Concise plugin description (detailed plugin guidelines not allow more of 151 characters)
- Use of use Semantic Versioning MAJOR.MINOR.PATCH 1.0.0-beta instead 1.0-beta
- Corrected license spacing
- Network support (multisite)
- Secureds ABSPATH code
- Corrected capitalization for Block Editor and Classic Editor
- Removes redundant words to maintain description in the same line
- Corrects the case where the plugin updates lose and delete user-defined custom settings
- Corrects the case where the plugin deactivation lose and delete user-defined custom settings
- Minor general code tweaks