### PR TITLE
Fix static call of non-static save_network_settings

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -355,7 +355,7 @@ class Classic_Editor {
 		<?php
 	}
 
-	public function save_network_settings() {
+	public static function save_network_settings() {
 		if (
 			isset( $_POST['classic-editor-network-settings'] ) &&
 			current_user_can( 'manage_network_options' ) &&


### PR DESCRIPTION
Trying to save the network settings here:
<img width="960" alt="screen shot 2018-12-05 at 3 21 35 pm" src="https://user-images.githubusercontent.com/530877/49548265-5e94ca80-f8a2-11e8-9079-0c8c274704cf.png">

Leads to a warning:
<img width="751" alt="screen shot 2018-12-05 at 3 21 57 pm" src="https://user-images.githubusercontent.com/530877/49548253-5a68ad00-f8a2-11e8-8a9b-d8e65f17ba5c.png">

This PR makes `save_network_settings` static as that seems to match the intent and fixes the issue of calling as static.