### PR TITLE
Consider disallowing users to switch editors by default

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -118,7 +118,7 @@ class Classic_Editor {
 		if ( is_array( $settings ) ) {
 			return array(
 				'editor' => ( isset( $settings['editor'] ) && $settings['editor'] === 'block' ) ? 'block' : 'classic',
-				'allow-users' => ( ! isset( $settings['allow-users'] ) || $settings['allow-users'] ), // Allow by default.
+				'allow-users' => ! empty( $settings['allow-users'] ),
 				'hide-settings-ui' => true,
 			);
 		}
@@ -768,7 +768,7 @@ class Classic_Editor {
 			update_option( 'classic-editor-replace', 'classic' );
 		}
 		if ( ! get_option( 'classic-editor-allow-users' ) ) {
-			update_option( 'classic-editor-allow-users', 'allow' );
+			update_option( 'classic-editor-allow-users', 'disallow' );
 		}
 		if ( is_multisite() ) {
 			update_network_option( null, 'classic-editor-allow-sites', 'disallow' );


### PR DESCRIPTION
This brings back the previous behavior of completely disabling the Block Editor on install for all users.