### PR TITLE
Bug fixes and updates

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -126,8 +126,19 @@ class Classic_Editor {
 		remove_action( 'admin_menu', 'gutenberg_menu' );
 		remove_action( 'admin_notices', 'gutenberg_build_files_notice' );
 		remove_action( 'admin_init', 'gutenberg_redirect_demo' );
+		remove_action( 'admin_init', 'gutenberg_add_edit_link_filters' );
+		remove_action( 'admin_print_scripts-edit.php', 'gutenberg_replace_default_add_new_button' );
+		remove_filter( 'body_class', 'gutenberg_add_responsive_body_class' );
+		remove_filter( 'admin_url', 'gutenberg_modify_add_new_button_url' );
 		// lib/compat.php
 		remove_filter( 'wp_refresh_nonces', 'gutenberg_add_rest_nonce_to_heartbeat_response_headers' );
+		remove_action( 'admin_enqueue_scripts', 'gutenberg_check_if_classic_needs_warning_about_blocks' );
+		// lib/register.php
+		remove_action( 'edit_form_top', 'gutenberg_remember_classic_editor_when_saving_posts' );
+		remove_filter( 'redirect_post_location', 'gutenberg_redirect_to_classic_editor_when_saving_posts' );
+		remove_filter( 'get_edit_post_link', 'gutenberg_revisions_link_to_editor' );
+		remove_filter( 'wp_prepare_revision_for_js', 'gutenberg_revisions_restore' );
+		remove_filter( 'display_post_states', 'gutenberg_add_gutenberg_post_state' );
 		// lib/rest-api.php
 		remove_action( 'rest_api_init', 'gutenberg_register_rest_routes' );
 		remove_action( 'rest_api_init', 'gutenberg_add_taxonomy_visibility_field' );
@@ -143,29 +154,13 @@ class Classic_Editor {
 		remove_filter( 'redirect_post_location', 'gutenberg_meta_box_save_redirect' );
 		remove_filter( 'filter_gutenberg_meta_boxes', 'gutenberg_filter_meta_boxes' );
 
-		// gutenberg.php
-		remove_action( 'admin_init', 'gutenberg_add_edit_link_filters' );
-		remove_action( 'admin_print_scripts-edit.php', 'gutenberg_replace_default_add_new_button' );
-		remove_filter( 'body_class', 'gutenberg_add_responsive_body_class' );
-		remove_filter( 'admin_url', 'gutenberg_modify_add_new_button_url' );
 		// Keep
 		// remove_filter( 'wp_kses_allowed_html', 'gutenberg_kses_allowedtags', 10, 2 ); // not needed in 5.0
 		// remove_filter( 'bulk_actions-edit-wp_block', 'gutenberg_block_bulk_actions' );
-		// lib/compat.php
-		remove_action( 'admin_enqueue_scripts', 'gutenberg_check_if_classic_needs_warning_about_blocks' );
-		// lib/register.php
-		remove_action( 'edit_form_top', 'gutenberg_remember_classic_editor_when_saving_posts' );
-		remove_filter( 'redirect_post_location', 'gutenberg_redirect_to_classic_editor_when_saving_posts' );
-		remove_filter( 'get_edit_post_link', 'gutenberg_revisions_link_to_editor' );
-		remove_filter( 'wp_prepare_revision_for_js', 'gutenberg_revisions_restore' );
-		remove_filter( 'display_post_states', 'gutenberg_add_gutenberg_post_state' );
-		// lib/plugin-compat.php
-		remove_filter( 'wp_insert_post_data', 'gutenberg_remove_wpcom_markdown_support' );
-		// Keep
-		// lib/blocks.php
+		// remove_filter( 'wp_insert_post_data', 'gutenberg_remove_wpcom_markdown_support' );
 		// remove_filter( 'the_content', 'do_blocks', 9 );
 		// Continue to disable wpautop inside TinyMCE for posts that were started in Gutenberg.
-		// remove_filter( 'wp_editor_settings', 'gutenberg_disable_editor_settings_wpautop' );
+		// remove_filter( 'wp_editor_settings', 'gutenberg_disable_editor_settings_wpautop' ); 
 		// Keep the tweaks to the PHP wpautop.
 		// add_filter( 'the_content', 'wpautop' );
 		// remove_filter( 'the_content', 'gutenberg_wpautop', 8 );

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Classic Editor ===
 Contributors: azaozz, melchoyce, chanthaboune, alexislloyd, pento, youknowriad, desrosj, luciano-croce
 Tags: editor, classic editor, block editor, gutenberg
-Requires at least: 5.0
+Requires at least: 4.9
 Tested up to: 5.0
-Stable tag: 0.5
+Stable tag: 1.1
 Requires PHP: 5.2.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -22,48 +22,53 @@ At a glance, this plugin adds the following:
 * When allowed, the users can choose which editor to use for each post.
 * Each post opens in the last editor used regardless of who edited it last. This is important for maintaining a consistent experience when editing content.
 
-The Classic Editor plugin supports WordPress version 4.9, so it can be installed and configured before WordPress is upgraded to version 5.0. In this case, only the admin settings are visible.
-
 In addition, the Classic Editor plugin includes several filters that let other plugins control the settings, and the editor choice per post and per post type.
 
 Classic Editor is an official WordPress plugin, and will be maintained until at least 2022.
 
 == Changelog ==
 
+= 1.2 =
+* Fixed switching editors from the Add New (post) screen before a draft post is saved.
+* Fixed typo that was appending the edit URL to the `classic-editor` query var.
+* Changed the default value of the option to allow users to switch editors to false.
+* Added disabling of the Gutenberg plugin and lowered the required WordPress version to 4.9.
+* Added `classic_editor_network_default_settings` filter.
+
 = 1.1 =
 Fixed a bug where it may attempt to load the Block Editor for post types that do not support editor when users are allowed to switch editors.
 
 = 1.0 =
-Updated for WordPress 5.0.
-Changed all "Gutenberg" names/references to "Block Editor".
-Refreshed the settings UI.
-Removed disabling of the Gutenberg plugin. This was added for testing in WordPress 4.9. Users who want to continue following the development of Gutenberg in WordPress 5.0 and beyond will not need another plugin to disable it.
-Added support for per-user settings of default editor.
-Added support for admins to set the default editor for the site.
-Added support for admins to allow users to change their default editor.
-Added support for network admins to prevent site admins from changing the default settings.
-Added support to store the last editor used for each post and open it next time. Enabled when users can choose default editor.
-Added "post editor state" in the listing of posts on the Posts screen. Shows the editor that will be opened for the post. Enabled when users can choose default editor.
-Added `classic_editor_enabled_editors_for_post` and `classic_editor_enabled_editors_for_post_type` filters. Can be used by other plugins to control or override the editor used for a particular post of post type.
-Added `classic_editor_plugin_settings` filter. Can be used by other plugins to override the settings and disable the settings UI.
+* Updated for WordPress 5.0.
+* Changed all "Gutenberg" names/references to "Block Editor".
+* Refreshed the settings UI.
+* Removed disabling of the Gutenberg plugin. This was added for testing in WordPress 4.9. Users who want to continue following the development of Gutenberg in WordPress 5.0 and beyond will not need another plugin to disable it.
+* Added support for per-user settings of default editor.
+* Added support for admins to set the default editor for the site.
+* Added support for admins to allow users to change their default editor.
+* Added support for network admins to prevent site admins from changing the default settings.
+* Added support to store the last editor used for each post and open it next time. Enabled when users can choose default editor.
+* Added "post editor state" in the listing of posts on the Posts screen. Shows the editor that will be opened for the post. Enabled when users can choose default editor.
+* Added `classic_editor_enabled_editors_for_post` and `classic_editor_enabled_editors_for_post_type` filters. Can be used by other plugins to control or override the editor used for a particular post of post type.
+* Added `classic_editor_plugin_settings` filter. Can be used by other plugins to override the settings and disable the settings UI.
 
 = 0.5 =
-Updated for Gutenberg 4.1 and WordPress 5.0-beta1.
-Removed some functionality that now exists in Gutenberg.
-Fixed redirecting back to the CLassic editor after looking at post revisions.
+* Updated for Gutenberg 4.1 and WordPress 5.0-beta1.
+* Removed some functionality that now exists in Gutenberg.
+* Fixed redirecting back to the CLassic editor after looking at post revisions.
 
 = 0.4 =
-Fixed removing of the "Try Gutenberg" call-out when the Gutenberg plugin is not activated.
-Fixed to always show the settings and the settings link in the plugins list table.
-Updated the readme text.
+* Fixed removing of the "Try Gutenberg" call-out when the Gutenberg plugin is not activated.
+* Fixed to always show the settings and the settings link in the plugins list table.
+* Updated the readme text.
 
 = 0.3 =
-Updated the option from a checkbox to couple of radio buttons, seems clearer. Thanks to @designsimply for the label text suggestions.
-Some general updates and cleanup.
+* Updated the option from a checkbox to couple of radio buttons, seems clearer. Thanks to @designsimply for the label text suggestions.
+* Some general updates and cleanup.
 
 = 0.2 =
-Update for Gutenberg 1.9.
-Remove warning and automatic deactivation when Gutenberg is not active.
+* Update for Gutenberg 1.9.
+* Remove warning and automatic deactivation when Gutenberg is not active.
 
 = 0.1 =
 Initial release.

--- a/readme.txt
+++ b/readme.txt
@@ -31,6 +31,7 @@ Classic Editor is an official WordPress plugin, and will be maintained until at 
 = 1.2 =
 * Fixed switching editors from the Add New (post) screen before a draft post is saved.
 * Fixed typo that was appending the edit URL to the `classic-editor` query var.
+* Changed detecting of WordPress 5.0 to not use version check. Fixes a bug when testing 5.1-alpha.
 * Changed the default value of the option to allow users to switch editors to false.
 * Added disabling of the Gutenberg plugin and lowered the required WordPress version to 4.9.
 * Added `classic_editor_network_default_settings` filter.


### PR DESCRIPTION
* Fixed switching editors from the Add New (post) screen before a draft post is saved.
* Fixed typo that was appending the edit URL to the `classic-editor` query var.
* Changed the default value of the option to allow users to switch editors to false.
* Added disabling of the Gutenberg plugin and lowered the required WordPress version to 4.9.
* Added `classic_editor_network_default_settings` filter.