### PR TITLE
Error in const plugin_version

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! class_exists( 'Classic_Editor' ) ) :
 class Classic_Editor {
-	const plugin_version = 1.0;
+	const plugin_version = 1.2;
 	private static $settings;
 	private static $supported_post_types = array();
 


### PR DESCRIPTION
- Error in const plugin_version: chabge -> const plugin_version = 1.0; to -> const plugin_version = 1.2;

Also same error in wordpress.org plugin repository: change -> const plugin_version = 1.0; -> const plugin_version = 1.1;