### PR TITLE
block-editor-plugin.js -- reduce the script size when it is enabled

### DIFF
--- a/js/block-editor-plugin.js
+++ b/js/block-editor-plugin.js
@@ -4,12 +4,10 @@
 	const { PluginMoreMenuItem } = wp.editPost;
 	const { addQueryArgs } = wp.url;
 	const { registerPlugin } = wp.plugins;
-
 	registerPlugin( 'classic-editor-add-submenu', {
 		render() {
 			const url = addQueryArgs( document.location.href, { 'classic-editor': null } );
 			const linkText = get( window, [ 'classicEditorPluginL10n', 'linkText' ] ) || 'Switch to Classic Editor';
-
 			return createElement(
 				PluginMoreMenuItem,
 				{


### PR DESCRIPTION
- Deleting all blank lines to reduce the script size when it is enabled
- Consider the possibility of creating a minifiled file

block-editor-plugin.js
block-editor-plugin.min.js

IMHO a smaller size is always better, and speed-up loading.

Related PR: https://github.com/WordPress/classic-editor/pull/48