### PR TITLE
Add a Network Admin action link to the Settings

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -5,7 +5,7 @@
  * Plugin Name: Classic Editor
  * Plugin URI:  https://wordpress.org/plugins/classic-editor/
  * Description: Enables the WordPress classic editor and the old-style Edit Post screen with TinyMCE, Meta Boxes, etc. Supports the older plugins that extend this screen.
- * Version:     1.3
+ * Version:     1.4-alpha
  * Author:      WordPress Contributors
  * Author URI:  https://github.com/WordPress/classic-editor/
  * License:     GPLv2 or later
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! class_exists( 'Classic_Editor' ) ) :
 class Classic_Editor {
-	const plugin_version = 1.2;
+	const plugin_version = 1.4;
 	private static $settings;
 	private static $supported_post_types = array();
 
@@ -51,6 +51,10 @@ class Classic_Editor {
 		if ( ! $settings['hide-settings-ui'] ) {
 			// Show the plugin's admin settings, and a link to them in the plugins list table.
 			add_filter( 'plugin_action_links', array( __CLASS__, 'add_settings_link' ), 10, 2 );
+
+			// Show the plugin's network admin settings, and a link to them in the plugins list table.
+			add_filter( 'network_admin_plugin_action_links', array( __CLASS__, 'add_network_settings_link' ), 10, 2 );
+
 			add_action( 'admin_init', array( __CLASS__, 'register_settings' ) );
 
 			if ( $settings['allow-users'] ) {
@@ -669,6 +673,19 @@ class Classic_Editor {
 			'classicEditorPluginL10n',
 			array( 'linkText' => __( 'Switch to Classic Editor', 'classic-editor' ) )
 		);
+	}
+
+	/**
+	 * Add a link in network admin to the settings on the Plugins screen.
+	 */
+	public static function add_network_settings_link( $links, $file ) {
+		$settings = self::get_settings();
+
+		if ( $file === 'classic-editor/classic-editor.php' && ! $settings['hide-settings-ui'] && current_user_can( 'manage_options' ) ) {
+			(array) $links[] = sprintf( '<a href="%s">%s</a>', admin_url( '/network/settings.php#classic-editor-allow-sites' ), __( 'Settings', 'classic-editor' ) );
+		}
+
+		return $links;
 	}
 
 	/**

--- a/classic-editor.php
+++ b/classic-editor.php
@@ -5,7 +5,7 @@
  * Plugin Name: Classic Editor
  * Plugin URI:  https://wordpress.org/plugins/classic-editor/
  * Description: Enables the WordPress classic editor and the old-style Edit Post screen with TinyMCE, Meta Boxes, etc. Supports the older plugins that extend this screen.
- * Version:     1.4-alpha
+ * Version:     1.3
  * Author:      WordPress Contributors
  * Author URI:  https://github.com/WordPress/classic-editor/
  * License:     GPLv2 or later
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! class_exists( 'Classic_Editor' ) ) :
 class Classic_Editor {
-	const plugin_version = 1.4;
+	const plugin_version = 1.3;
 	private static $settings;
 	private static $supported_post_types = array();
 
@@ -682,7 +682,9 @@ class Classic_Editor {
 		$settings = self::get_settings();
 
 		if ( $file === 'classic-editor/classic-editor.php' && ! $settings['hide-settings-ui'] && current_user_can( 'manage_options' ) ) {
-			(array) $links[] = sprintf( '<a href="%s">%s</a>', admin_url( '/network/settings.php#classic-editor-allow-sites' ), __( 'Settings', 'classic-editor' ) );
+			// Prevent warnings in PHP 7.0+ when a plugin uses this filter incorrectly.
+			$links = (array) $links;
+			$links[] = sprintf( '<a href="%s">%s</a>', admin_url( '/network/settings.php#classic-editor-allow-sites' ), __( 'Settings', 'classic-editor' ) );
 		}
 
 		return $links;
@@ -695,7 +697,9 @@ class Classic_Editor {
 		$settings = self::get_settings();
 
 		if ( $file === 'classic-editor/classic-editor.php' && ! $settings['hide-settings-ui'] && current_user_can( 'manage_options' ) ) {
-			(array) $links[] = sprintf( '<a href="%s">%s</a>', admin_url( 'options-writing.php#classic-editor-options' ), __( 'Settings', 'classic-editor' ) );
+			// Prevent warnings in PHP 7.0+ when a plugin uses this filter incorrectly.
+			$links = (array) $links;
+			$links[] = sprintf( '<a href="%s">%s</a>', admin_url( 'options-writing.php#classic-editor-options' ), __( 'Settings', 'classic-editor' ) );
 		}
 
 		return $links;


### PR DESCRIPTION
- Add a network admin action link to the Settings on the Plugins screen.

Show the plugin's network admin settings, and a link to them in the plugins list table.