### PR TITLE
Remove forced network only activation

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -12,7 +12,6 @@
  * License URI: http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  * Text Domain: classic-editor
  * Domain Path: /languages
- * Network:     true
  *
  * This program is free software; you can redistribute it and/or modify it under the terms of the GNU
  * General Public License version 2, as published by the Free Software Foundation. You may NOT assume


### PR DESCRIPTION
Remove the  `* Network: true` until there is an option to set the default editor network wide.

Currently, with the plugin activation set to network wide only, there is no way to use this plugin on a multisite where super admin wants the block editor to remain the default while allowing site admins to revert to the classic editor.