### PR TITLE
Capitalize "classic editor" in description

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -4,7 +4,7 @@
  *
  * Plugin Name: Classic Editor
  * Plugin URI:  https://wordpress.org/plugins/classic-editor/
- * Description: Enables the WordPress classic editor and the old-style Edit Post screen with TinyMCE, Meta Boxes, etc. Supports the older plugins that extend this screen.
+ * Description: Enables the WordPress Classic Editor and the old-style Edit Post screen with TinyMCE, Meta Boxes, etc. Supports the older plugins that extend this screen.
  * Version:     1.4-alpha
  * Author:      WordPress Contributors
  * Author URI:  https://github.com/WordPress/classic-editor/
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! class_exists( 'Classic_Editor' ) ) :
 class Classic_Editor {
-	const plugin_version = 1.4-alpha;
+	const plugin_version = 1.4;
 
 	private static $settings;
 	private static $supported_post_types = array();


### PR DESCRIPTION
classic-editor.php - capitalize "classic editor" in description

Enables the WordPress **classic editor** and the old-style Edit Post screen with TinyMCE, Meta Boxes, etc. Supports the older plugins that extend this screen.

Enables the WordPress **Classic Editor** and the old-style Edit Post screen with TinyMCE, Meta Boxes, etc. Supports the older plugins that extend this screen.