### PR TITLE
Always show Network Admin link to the Settings

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 if ( ! class_exists( 'Classic_Editor' ) ) :
 class Classic_Editor {
-	const plugin_version = 1.4-alpha;
+	const plugin_version = 1.4;
 
 	private static $settings;
 	private static $supported_post_types = array();
@@ -702,7 +702,7 @@ class Classic_Editor {
 	public static function add_network_settings_link( $links, $file ) {
 		$settings = self::get_settings();
 
-		if ( $file === 'classic-editor/classic-editor.php' && ! $settings['hide-settings-ui'] && current_user_can( 'manage_options' ) ) {
+		if ( $file === 'classic-editor/classic-editor.php' && $settings['hide-settings-ui'] && current_user_can( 'manage_options' ) ) {
 			// Prevent warnings in PHP 7.0+ when a plugin uses this filter incorrectly.
 			$links = (array) $links;
 			$links[] = sprintf( '<a href="%s">%s</a>', admin_url( '/network/settings.php#classic-editor-allow-sites' ), __( 'Settings', 'classic-editor' ) );


### PR DESCRIPTION
Always show Network Admin action link to the Settings.

This PR patch my previous PR #52 -> "Add a Network Admin action link to the Settings"

Actually Settings link in Networl Admin is showed only if the option "Allow site admins to change settings" is checked.

OMG ERROR

The Settings link must always be active, just like it happens in a standalone installation!

This PR correct this aspect.