### PR TITLE
Uncapitalize Settings in string Editor Settings

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -438,7 +438,7 @@ class Classic_Editor {
 		$is_checked = ( get_network_option( null, 'classic-editor-allow-sites' ) === 'allow' );
 
 		?>
-		<h2 id="classic-editor-options"><?php _e( 'Editor Settings', 'classic-editor' ); ?></h2>
+		<h2 id="classic-editor-options"><?php _e( 'Editor settings', 'classic-editor' ); ?></h2>
 		<table class="form-table">
 			<?php wp_nonce_field( 'allow-site-admin-settings', 'classic-editor-network-settings' ); ?>
 			<tr>


### PR DESCRIPTION
Please uncapitalize "Settings" in string "Editor Settings" -> Editor settings in line 441

Note that all other similar strings are uncapitalized, for example -> Change settings in line 458