### PR TITLE
Updated Block Editor and Classic Editor instances to lowercase

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -99,7 +99,7 @@ class Classic_Editor {
 		} else {
 			if ( $settings['editor'] === 'classic' ) {
 				if ( $block_editor ) {
-					// Consider disabling other Block Editor functionality.
+					// Consider disabling other block editor functionality.
 					add_filter( 'use_block_editor_for_post_type', '__return_false', 100 );
 				}
 				if ( $gutenberg ) {
@@ -271,7 +271,7 @@ class Classic_Editor {
 			if ( $settings['allow-users'] && ! isset( $_GET['classic-editor__forget'] ) ) {
 				$which = get_post_meta( $post_id, 'classic-editor-remember', true );
 
-				// The editor choice will be "remembered" when the post is opened in either Classic or Block editor.
+				// The editor choice will be "remembered" when the post is opened in either classic editor or block editor.
 				if ( 'classic-editor' === $which ) {
 					return true;
 				} elseif ( 'block-editor' === $which ) {
@@ -368,11 +368,11 @@ class Classic_Editor {
 		<div class="classic-editor-options">
 			<p>
 				<input type="radio" name="classic-editor-replace" id="classic-editor-classic" value="classic"<?php if ( $settings['editor'] === 'classic' ) echo ' checked'; ?> />
-				<label for="classic-editor-classic"><?php _ex( 'Classic Editor', 'Editor Name', 'classic-editor' ); ?></label>
+				<label for="classic-editor-classic"><?php _ex( 'Classic editor', 'Editor Name', 'classic-editor' ); ?></label>
 			</p>
 			<p>
 				<input type="radio" name="classic-editor-replace" id="classic-editor-block" value="block"<?php if ( $settings['editor'] !== 'classic' ) echo ' checked'; ?> />
-				<label for="classic-editor-block"><?php _ex( 'Block Editor', 'Editor Name', 'classic-editor' ); ?></label>
+				<label for="classic-editor-block"><?php _ex( 'Block editor', 'Editor Name', 'classic-editor' ); ?></label>
 			</p>
 		</div>
 		<script>
@@ -445,11 +445,11 @@ class Classic_Editor {
 				<td>
 					<p>
 						<input type="radio" name="classic-editor-replace" id="classic-editor-classic" value="classic"<?php if ( $editor !== 'block' ) echo ' checked'; ?> />
-						<label for="classic-editor-classic"><?php _ex( 'Classic Editor', 'Editor Name', 'classic-editor' ); ?></label>
+						<label for="classic-editor-classic"><?php _ex( 'Classic editor', 'Editor Name', 'classic-editor' ); ?></label>
 					</p>
 					<p>
 						<input type="radio" name="classic-editor-replace" id="classic-editor-block" value="block"<?php if ( $editor === 'block' ) echo ' checked'; ?> />
-						<label for="classic-editor-block"><?php _ex( 'Block Editor', 'Editor Name', 'classic-editor' ); ?></label>
+						<label for="classic-editor-block"><?php _ex( 'Block editor', 'Editor Name', 'classic-editor' ); ?></label>
 					</p>
 				</td>
 			</tr>
@@ -458,7 +458,7 @@ class Classic_Editor {
 				<td>
 					<input type="checkbox" name="classic-editor-allow-sites" id="classic-editor-allow-sites" value="allow"<?php if ( $is_checked ) echo ' checked'; ?>>
 					<label for="classic-editor-allow-sites"><?php _e( 'Allow site admins to change settings', 'classic-editor' ); ?></label>
-					<p class="description"><?php _e( 'By default the Block Editor is replaced with the Classic Editor and users cannot switch editors.', 'classic-editor' ); ?></p>
+					<p class="description"><?php _e( 'By default the block editor is replaced with the classic editor and users cannot switch editors.', 'classic-editor' ); ?></p>
 				</td>
 			</tr>
 		</table>
@@ -497,11 +497,11 @@ class Classic_Editor {
 		) {
 			// No need to show when the user cannot edit posts,
 			// the settings are preset from another plugin,
-			// or when not replacing the Block Editor.
+			// or when not replacing the block editor.
 			return;
 		}
 
-		$message = __( 'The Classic Editor plugin prevents use of the new Block Editor.', 'classic-editor' );
+		$message = __( 'The Classic Editor plugin prevents use of the new block editor.', 'classic-editor' );
 
 		if ( current_user_can( 'manage_options' ) ) {
 			if ( is_network_admin() ) {
@@ -524,7 +524,7 @@ class Classic_Editor {
 
 	/**
 	 * Add a hidden field in edit-form-advanced.php
-	 * to help redirect back to the Classic Editor on saving.
+	 * to help redirect back to the classic editor on saving.
 	 */
 	public static function add_redirect_helper() {
 		?>
@@ -533,7 +533,7 @@ class Classic_Editor {
 	}
 
 	/**
-	 * Remember when the Classic Editor was used to edit a post.
+	 * Remember when the classic editor was used to edit a post.
 	 */
 	public static function remember_classic_editor( $post ) {
 		$post_type = get_post_type( $post );
@@ -544,7 +544,7 @@ class Classic_Editor {
 	}
 
 	/**
-	 * Remember when the Block Editor was used to edit a post.
+	 * Remember when the block editor was used to edit a post.
 	 */
 	public static function remember_block_editor( $editor_settings, $post ) {
 		$post_type = get_post_type( $post );
@@ -565,13 +565,13 @@ class Classic_Editor {
 	/**
 	 * Choose which editor to use for a post.
 	 *
-	 * Passes through `$which_editor` for Block Editor (it's sets to `true` but may be changed by another plugin).
+	 * Passes through `$which_editor` for block editor (it's sets to `true` but may be changed by another plugin).
 	 *
 	 * @uses `use_block_editor_for_post` filter.
 	 *
-	 * @param boolean $use_block_editor True for Block Editor, false for Classic Editor.
+	 * @param boolean $use_block_editor True for block editor, false for classic editor.
 	 * @param WP_Post $post             The post being edited.
-	 * @return boolean True for Block Editor, false for Classic Editor.
+	 * @return boolean True for block editor, false for classic editor.
 	 */
 	public static function choose_editor( $use_block_editor, $post ) {
 		$settings = self::get_settings();
@@ -587,7 +587,7 @@ class Classic_Editor {
 		if ( empty( $post->ID ) || $post->post_status === 'auto-draft' ) {
 			if (
 				( $settings['editor'] === 'classic' && ! isset( $_GET['classic-editor__forget'] ) ) ||  // Add New
-				( isset( $_GET['classic-editor'] ) && isset( $_GET['classic-editor__forget'] ) ) // Switch to Classic Editor when no draft post.
+				( isset( $_GET['classic-editor'] ) && isset( $_GET['classic-editor__forget'] ) ) // Switch to classic editor when no draft post.
 			) {
 				$use_block_editor = false;
 			}
@@ -653,14 +653,14 @@ class Classic_Editor {
 	public static function do_meta_box( $post ) {
 		$edit_url = get_edit_post_link( $post->ID, 'raw' );
 
-		// Switching to Block Editor.
+		// Switching to block editor.
 		$edit_url = remove_query_arg( 'classic-editor', $edit_url );
 		// Forget the previous value when going to a specific editor.
 		$edit_url = add_query_arg( 'classic-editor__forget', '', $edit_url );
 
 		?>
 		<p style="margin: 1em 0;">
-			<a href="<?php echo esc_url( $edit_url ); ?>"><?php _e( 'Switch to Block Editor', 'classic-editor' ); ?></a>
+			<a href="<?php echo esc_url( $edit_url ); ?>"><?php _e( 'Switch to block editor', 'classic-editor' ); ?></a>
 		</p>
 		<?php
 	}
@@ -684,7 +684,7 @@ class Classic_Editor {
 		wp_localize_script(
 			'classic-editor-plugin',
 			'classicEditorPluginL10n',
-			array( 'linkText' => __( 'Switch to Classic Editor', 'classic-editor' ) )
+			array( 'linkText' => __( 'Switch to classic editor', 'classic-editor' ) )
 		);
 	}
 
@@ -781,7 +781,7 @@ class Classic_Editor {
 
 	/**
 	 * Adds links to the post/page screens to edit any post or page in
-	 * the Classic Editor or Block Editor.
+	 * the classic editor or block editor.
 	 *
 	 * @param  array   $actions Post actions.
 	 * @param  WP_Post $post    Edited post.
@@ -816,18 +816,18 @@ class Classic_Editor {
 		// Build the edit actions. See also: WP_Posts_List_Table::handle_row_actions().
 		$title = _draft_or_post_title( $post->ID );
 
-		// Link to the Block Editor.
+		// Link to the block editor.
 		$url = remove_query_arg( 'classic-editor', $edit_url );
-		$text = _x( 'Edit (Block Editor)', 'Editor Name', 'classic-editor' );
+		$text = _x( 'Edit (block editor)', 'Editor Name', 'classic-editor' );
 		/* translators: %s: post title */
-		$label = sprintf( __( 'Edit &#8220;%s&#8221; in the Block Editor', 'classic-editor' ), $title );
+		$label = sprintf( __( 'Edit &#8220;%s&#8221; in the block editor', 'classic-editor' ), $title );
 		$edit_block = sprintf( '<a href="%s" aria-label="%s">%s</a>', esc_url( $url ), esc_attr( $label ), $text );
 
-		// Link to the Classic Editor.
+		// Link to the classic editor.
 		$url = add_query_arg( 'classic-editor', '', $edit_url );
-		$text = _x( 'Edit (Classic Editor)', 'Editor Name', 'classic-editor' );
+		$text = _x( 'Edit (classic editor)', 'Editor Name', 'classic-editor' );
 		/* translators: %s: post title */
-		$label = sprintf( __( 'Edit &#8220;%s&#8221; in the Classic Editor', 'classic-editor' ), $title );
+		$label = sprintf( __( 'Edit &#8220;%s&#8221; in the classic editor', 'classic-editor' ), $title );
 		$edit_classic = sprintf( '<a href="%s" aria-label="%s">%s</a>', esc_url( $url ), esc_attr( $label ), $text );
 
 		$edit_actions = array(
@@ -851,11 +851,11 @@ class Classic_Editor {
 		if ( ! $editors['classic_editor'] && ! $editors['block_editor'] ) {
 			return $post_states;
 		} elseif ( $editors['classic_editor'] && ! $editors['block_editor'] ) {
-			// Forced to Classic Editor.
-			$state = '<span class="classic-editor-forced-state">' . _x( 'Classic Editor', 'Editor Name', 'classic-editor' ) . '</span>';
+			// Forced to classic editor.
+			$state = '<span class="classic-editor-forced-state">' . _x( 'classic editor', 'Editor Name', 'classic-editor' ) . '</span>';
 		} elseif ( ! $editors['classic_editor'] && $editors['block_editor'] ) {
-			// Forced to Block Editor.
-			$state = '<span class="classic-editor-forced-state">' . _x( 'Block Editor', 'Editor Name', 'classic-editor' ) . '</span>';
+			// Forced to block editor.
+			$state = '<span class="classic-editor-forced-state">' . _x( 'block editor', 'Editor Name', 'classic-editor' ) . '</span>';
 		} else {
 			$last_editor = get_post_meta( $post->ID, 'classic-editor-remember', true );
 
@@ -866,7 +866,7 @@ class Classic_Editor {
 				$is_classic = ( $settings['editor'] === 'classic' );
 			}
 
-			$state = $is_classic ? _x( 'Classic Editor', 'Editor Name', 'classic-editor' ) : _x( 'Block Editor', 'Editor Name', 'classic-editor' );
+			$state = $is_classic ? _x( 'classic editor', 'Editor Name', 'classic-editor' ) : _x( 'block editor', 'Editor Name', 'classic-editor' );
 		}
 
 		(array) $post_states[] = $state;

--- a/classic-editor.php
+++ b/classic-editor.php
@@ -856,7 +856,7 @@ class Classic_Editor {
 				$is_classic = ( $settings['editor'] === 'classic' );
 			}
 
-			$state = $is_classic ? _x( 'classic editor', 'Editor Name', 'classic-editor' ) : _x( 'block editor', 'Editor Name', 'classic-editor' );
+			$state = $is_classic ? _x( 'Classic editor', 'Editor Name', 'classic-editor' ) : _x( 'Block editor', 'Editor Name', 'classic-editor' );
 		}
 
 		// Fix PHP 7+ warnings if another plugin returns unexpected type.

--- a/js/block-editor-plugin.js
+++ b/js/block-editor-plugin.js
@@ -8,7 +8,7 @@
 			var createElement = wp.element.createElement;
 			var PluginMoreMenuItem = wp.editPost.PluginMoreMenuItem;
 			var url = wp.url.addQueryArgs( document.location.href, { 'classic-editor': '', 'classic-editor__forget': '' } );
-			var linkText = lodash.get( window, [ 'classicEditorPluginL10n', 'linkText' ] ) || 'Switch to Classic Editor';
+			var linkText = lodash.get( window, [ 'classicEditorPluginL10n', 'linkText' ] ) || 'Switch to classic editor';
 
 			return createElement(
 				PluginMoreMenuItem,

--- a/readme.txt
+++ b/readme.txt
@@ -25,7 +25,7 @@ At a glance, this plugin adds the following:
 
 In addition, the Classic Editor plugin includes several filters that let other plugins control the settings, and the editor choice per post and per post type.
 
-By default, this plugin hides all functionality available in the new Block Editor ("Gutenberg").
+By default, this plugin hides all functionality available in the new block editor ("Gutenberg").
 
 == Changelog ==
 
@@ -33,11 +33,11 @@ By default, this plugin hides all functionality available in the new Block Edito
 * On network installations removed the restriction for only network activation.
 * Added support for network administrators to choose the default network-wide editor.
 * Fixed the settings link in the warning on network About screen.
-* Properly added the "Switch to Classic Editor" menu item to the Block Editor menu. 
+* Properly added the "Switch to classic editor" menu item to the block editor menu. 
 
 = 1.3 =
 * Fixed removal of the "Try Gutenberg" dashboard widget.
-* Fixed condition for displaying of the after upgrade notice on the "What's New" screen. Shown when the Classic Editor is selected and users cannot switch editors.
+* Fixed condition for displaying of the after upgrade notice on the "What's New" screen. Shown when the classic editor is selected and users cannot switch editors.
 
 = 1.2 =
 * Fixed switching editors from the Add New (post) screen before a draft post is saved.
@@ -48,11 +48,11 @@ By default, this plugin hides all functionality available in the new Block Edito
 * Added `classic_editor_network_default_settings` filter.
 
 = 1.1 =
-Fixed a bug where it may attempt to load the Block Editor for post types that do not support editor when users are allowed to switch editors.
+Fixed a bug where it may attempt to load the block editor for post types that do not support editor when users are allowed to switch editors.
 
 = 1.0 =
 * Updated for WordPress 5.0.
-* Changed all "Gutenberg" names/references to "Block Editor".
+* Changed all "Gutenberg" names/references to "block editor".
 * Refreshed the settings UI.
 * Removed disabling of the Gutenberg plugin. This was added for testing in WordPress 4.9. Users who want to continue following the development of Gutenberg in WordPress 5.0 and beyond will not need another plugin to disable it.
 * Added support for per-user settings of default editor.
@@ -67,7 +67,7 @@ Fixed a bug where it may attempt to load the Block Editor for post types that do
 = 0.5 =
 * Updated for Gutenberg 4.1 and WordPress 5.0-beta1.
 * Removed some functionality that now exists in Gutenberg.
-* Fixed redirecting back to the Classic Editor after looking at post revisions.
+* Fixed redirecting back to the classic editor after looking at post revisions.
 
 = 0.4 =
 * Fixed removing of the "Try Gutenberg" call-out when the Gutenberg plugin is not activated.
@@ -89,26 +89,26 @@ Initial release.
 
 = Default settings =
 
-When activated this plugin will restore the previous ("classic") WordPress editor and hide the new Block Editor ("Gutenberg").
+When activated this plugin will restore the previous ("classic") WordPress editor and hide the new block editor ("Gutenberg").
 These settings can be changed at the Settings => Writing screen.
 
 = Default settings for network installation =
 
 There are two options:
 
-* When network-activated this plugin will set the Classic Editor as default and prevent site administrators and users from changing editors.
+* When network-activated this plugin will set the classic editor as default and prevent site administrators and users from changing editors.
 The settings can be changed and default network-wide editor can be selected on the Network Settings screen.
 * When not network-activated each site administrator will be able to activate the plugin and choose options for their users.
 
-= Cannot find the "Switch to Classic Editor" link =
+= Cannot find the "Switch to classic editor" link =
 
-It is in the main Block Editor menu, see this [screenshot](https://ps.w.org/classic-editor/assets/screenshot-7.png?rev=2023480).
+It is in the main block editor menu, see this [screenshot](https://ps.w.org/classic-editor/assets/screenshot-7.png?rev=2023480).
 
 == Screenshots ==
 1. Admin settings on the Settings -> Writing screen.
 2. User settings on the Profile screen. Visible when the users are allowed to switch editors.
 3. "Action links" to choose alternative editor. Visible when the users are allowed to switch editors.
-4. Link to switch to the Block Editor while editing a post in the Classic Editor. Visible when the users are allowed to switch editors.
-5. Link to switch to the Classic Editor while editing a post in the Block Editor. Visible when the users are allowed to switch editors.
+4. Link to switch to the block editor while editing a post in the classic editor. Visible when the users are allowed to switch editors.
+5. Link to switch to the classic editor while editing a post in the block editor. Visible when the users are allowed to switch editors.
 6. Network settings to select the default editor for the network and allow site admins to change it.
-7. The "Switch to Classic Editor" link.
+7. The "Switch to classic editor" link.


### PR DESCRIPTION
Following the convention in core/Gutenberg I've started to lowercase the block editor and classic editor references when they're not referring to the Classic Editor plugin. Only other case is when it's a sentence then the first word is capitalized.

References;
Spelling - https://make.wordpress.org/core/handbook/best-practices/spelling/
Core Ticket - https://core.trac.wordpress.org/ticket/45634
Gutenberg Tickets;
Lowercase Block Editor - https://github.com/WordPress/gutenberg/pull/14205
Lowercase Classic Editor - https://github.com/WordPress/gutenberg/pull/14203
Original Discussion Ticket - https://github.com/WordPress/gutenberg/pull/12856
