### PR TITLE
Allow site administrators to change the default editor for other users.

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -200,7 +200,7 @@ class Classic_Editor {
 
 	}
 
-	private static function get_settings( $refresh = 'no', $opts_for_user = 0) {
+	private static function get_settings( $refresh = 'no', $user_id = 0 ) {
 		/**
 		 * Can be used to override the plugin's settings. Always hides the settings UI when used (as users cannot change the settings).
 		 *
@@ -273,13 +273,13 @@ class Classic_Editor {
 		// Override the defaults with the user options.
 		if ( ( ! isset( $GLOBALS['pagenow'] ) || $GLOBALS['pagenow'] !== 'options-writing.php' ) && $allow_users ) {
 
-			$user_options = get_user_option( 'classic-editor-settings', $opts_for_user);
+			$user_options = get_user_option( 'classic-editor-settings', $user_id );
 
 			if ( $user_options === 'block' || $user_options === 'classic' ) {
 				$editor = $user_options;
 			}
 		}
- 
+
 		self::$settings = array(
 			'editor' => $editor,
 			'hide-settings-ui' => false,
@@ -405,8 +405,8 @@ class Classic_Editor {
 		return 'disallow';
 	}
 
-	public static function settings_1( $opts_for_user=0 ) {
-		$settings = self::get_settings( 'refresh', $opts_for_user );
+	public static function settings_1( $user_id = 0 ) {
+		$settings = self::get_settings( 'refresh', $user_id );
 
 		?>
 		<div class="classic-editor-options">

--- a/classic-editor.php
+++ b/classic-editor.php
@@ -57,7 +57,9 @@ class Classic_Editor {
 			if ( $settings['allow-users'] ) {
 				// User settings.
 				add_action( 'personal_options_update', array( __CLASS__, 'save_user_settings' ) );
+				add_action( 'edit_user_profile_update', array( __CLASS__, 'save_user_settings' ) );
 				add_action( 'profile_personal_options', array( __CLASS__, 'user_settings' ) );
+				add_action( 'edit_user_profile', array( __CLASS__, 'user_settings') );
 			}
 		}
 
@@ -198,7 +200,7 @@ class Classic_Editor {
 
 	}
 
-	private static function get_settings( $refresh = 'no' ) {
+	private static function get_settings( $refresh = 'no', $opts_for_user = 0) {
 		/**
 		 * Can be used to override the plugin's settings. Always hides the settings UI when used (as users cannot change the settings).
 		 *
@@ -270,13 +272,14 @@ class Classic_Editor {
 
 		// Override the defaults with the user options.
 		if ( ( ! isset( $GLOBALS['pagenow'] ) || $GLOBALS['pagenow'] !== 'options-writing.php' ) && $allow_users ) {
-			$user_options = get_user_option( 'classic-editor-settings' );
+
+			$user_options = get_user_option( 'classic-editor-settings', $opts_for_user);
 
 			if ( $user_options === 'block' || $user_options === 'classic' ) {
 				$editor = $user_options;
 			}
 		}
-
+ 
 		self::$settings = array(
 			'editor' => $editor,
 			'hide-settings-ui' => false,
@@ -402,8 +405,8 @@ class Classic_Editor {
 		return 'disallow';
 	}
 
-	public static function settings_1() {
-		$settings = self::get_settings( 'refresh' );
+	public static function settings_1( $opts_for_user=0 ) {
+		$settings = self::get_settings( 'refresh', $opts_for_user );
 
 		?>
 		<div class="classic-editor-options">
@@ -446,13 +449,11 @@ class Classic_Editor {
 	/**
 	 * Shown on the Profile page when allowed by admin.
 	 */
-	public static function user_settings() {
+	public static function user_settings( $user ) {
 		global $user_can_edit;
 		$settings = self::get_settings( 'update' );
 
 		if (
-			! defined( 'IS_PROFILE_PAGE' ) ||
-			! IS_PROFILE_PAGE ||
 			! $user_can_edit ||
 			! $settings['allow-users']
 		) {
@@ -465,7 +466,7 @@ class Classic_Editor {
 				<th scope="row"><?php _e( 'Default Editor', 'classic-editor' ); ?></th>
 				<td>
 				<?php wp_nonce_field( 'allow-user-settings', 'classic-editor-user-settings' ); ?>
-				<?php self::settings_1(); ?>
+				<?php self::settings_1( $user->ID ); ?>
 				</td>
 			</tr>
 		</table>


### PR DESCRIPTION
Currently, site administrators and superadmins can't change the default editor for users on their site. This PR adds that functionality. 