### PR TITLE
register_uninstall_hook should be called in activate

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -37,7 +37,6 @@ class Classic_Editor {
 		$gutenberg = function_exists( 'gutenberg_register_scripts_and_styles' );
 
 		register_activation_hook( __FILE__, array( __CLASS__, 'activate' ) );
-		register_uninstall_hook( __FILE__, array( __CLASS__, 'uninstall' ) );
 
 		$settings = self::get_settings();
 
@@ -913,6 +912,8 @@ class Classic_Editor {
 	 * Set defaults on activation.
 	 */
 	public static function activate() {
+		register_uninstall_hook( __FILE__, array( __CLASS__, 'uninstall' ) );
+		
 		if ( is_multisite() ) {
 			add_network_option( null, 'classic-editor-replace', 'classic' );
 			add_network_option( null, 'classic-editor-allow-sites', 'disallow' );


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/register_uninstall_hook-is-not-properly-used/