### PR TITLE
Fix deprecated notice in WordPress 5.5.0-alpha

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -335,20 +335,17 @@ class Classic_Editor {
 			'sanitize_callback' => array( __CLASS__, 'validate_option_allow_users' ),
 		) );
 
-		if ( function_exists( 'add_option_allowed_list' ) ) {
-			add_option_allowed_list( array(
-				'writing' => array(
-					'classic-editor-replace',
-					'classic-editor-allow-users'
-				),
-			) );
+		$allowed_options = array(
+			'writing' => array(
+				'classic-editor-replace',
+				'classic-editor-allow-users'
+			),
+		);
+
+		if ( function_exists( 'add_allowed_options' ) ) {
+			add_allowed_options( $allowed_options );
 		} else {
-			add_option_whitelist( array(
-				'writing' => array(
-					'classic-editor-replace',
-					'classic-editor-allow-users'
-				),
-			) );
+			add_option_whitelist( $allowed_options );
 		}
 
 		$heading_1 = __( 'Default editor for all users', 'classic-editor' );

--- a/classic-editor.php
+++ b/classic-editor.php
@@ -335,9 +335,21 @@ class Classic_Editor {
 			'sanitize_callback' => array( __CLASS__, 'validate_option_allow_users' ),
 		) );
 
-		add_option_whitelist( array(
-			'writing' => array( 'classic-editor-replace', 'classic-editor-allow-users' ),
-		) );
+		if ( function_exists( 'add_option_allowed_list' ) ) {
+			add_option_allowed_list( array(
+				'writing' => array(
+					'classic-editor-replace',
+					'classic-editor-allow-users'
+				),
+			) );
+		} else {
+			add_option_whitelist( array(
+				'writing' => array(
+					'classic-editor-replace',
+					'classic-editor-allow-users'
+				),
+			) );
+		}
 
 		$heading_1 = __( 'Default editor for all users', 'classic-editor' );
 		$heading_2 = __( 'Allow users to switch editors', 'classic-editor' );


### PR DESCRIPTION
In 5.5.0, the function `add_option_whitelist()` will be deprecated. Anyone running `trunk` or nightly will see the message today after [Core changeset 48121](https://core.trac.wordpress.org/changeset/48121).

This PR will check that the new function exists to prevent the warning.