### PR TITLE
wpcs fixes

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -110,7 +110,7 @@ class Classic_Editor {
 					self::remove_gutenberg_hooks();
 				}
 			} else {
-				// The $settings['editor'] value is 'block' so there is nothing to do.
+				// $settings['editor'] === 'block', nothing to do :)
 				return;
 			}
 		}
@@ -258,7 +258,7 @@ class Classic_Editor {
 			if ( $option === 'block' || $option === 'no-replace' ) {
 				$editor = 'block';
 			} else {
-				// The $option variable is either empty, set to classic, or set to replace.
+				// empty( $option ) || $option === 'classic' || $option === 'replace'
 				$editor = 'classic';
 			}
 		}
@@ -404,11 +404,11 @@ class Classic_Editor {
 		<div class="classic-editor-options">
 			<p>
 				<input type="radio" name="classic-editor-replace" id="classic-editor-classic" value="classic"<?php if ( $settings['editor'] === 'classic' ) echo ' checked'; ?> />
-				<label for="classic-editor-classic"><?php echo esc_html_x( 'Classic editor', 'Editor Name', 'classic-editor' ); ?></label>
+				<label for="classic-editor-classic"><?php _ex( 'Classic editor', 'Editor Name', 'classic-editor' ); ?></label>
 			</p>
 			<p>
 				<input type="radio" name="classic-editor-replace" id="classic-editor-block" value="block"<?php if ( $settings['editor'] !== 'classic' ) echo ' checked'; ?> />
-				<label for="classic-editor-block"><?php echo esc_html_x( 'Block editor', 'Editor Name', 'classic-editor' ); ?></label>
+				<label for="classic-editor-block"><?php _ex( 'Block editor', 'Editor Name', 'classic-editor' ); ?></label>
 			</p>
 		</div>
 		<script>
@@ -428,11 +428,11 @@ class Classic_Editor {
 		<div class="classic-editor-options">
 			<p>
 				<input type="radio" name="classic-editor-allow-users" id="classic-editor-allow" value="allow"<?php if ( $settings['allow-users'] ) echo ' checked'; ?> />
-				<label for="classic-editor-allow"><?php esc_html_e( 'Yes', 'classic-editor' ); ?></label>
+				<label for="classic-editor-allow"><?php _e( 'Yes', 'classic-editor' ); ?></label>
 			</p>
 			<p>
 				<input type="radio" name="classic-editor-allow-users" id="classic-editor-disallow" value="disallow"<?php if ( ! $settings['allow-users'] ) echo ' checked'; ?> />
-				<label for="classic-editor-disallow"><?php esc_html_e( 'No', 'classic-editor' ); ?></label>
+				<label for="classic-editor-disallow"><?php _e( 'No', 'classic-editor' ); ?></label>
 			</p>
 		</div>
 		<?php
@@ -457,7 +457,7 @@ class Classic_Editor {
 		?>
 		<table class="form-table">
 			<tr class="classic-editor-user-options">
-				<th scope="row"><?php esc_html_e( 'Default Editor', 'classic-editor' ); ?></th>
+				<th scope="row"><?php _e( 'Default Editor', 'classic-editor' ); ?></th>
 				<td>
 				<?php wp_nonce_field( 'allow-user-settings', 'classic-editor-user-settings' ); ?>
 				<?php self::settings_1(); ?>
@@ -473,28 +473,28 @@ class Classic_Editor {
 		$is_checked = ( get_network_option( null, 'classic-editor-allow-sites' ) === 'allow' );
 
 		?>
-		<h2 id="classic-editor-options"><?php esc_html_e( 'Editor Settings', 'classic-editor' ); ?></h2>
+		<h2 id="classic-editor-options"><?php _e( 'Editor Settings', 'classic-editor' ); ?></h2>
 		<table class="form-table">
 			<?php wp_nonce_field( 'allow-site-admin-settings', 'classic-editor-network-settings' ); ?>
 			<tr>
-				<th scope="row"><?php esc_html_e( 'Default editor for all sites', 'classic-editor' ); ?></th>
+				<th scope="row"><?php _e( 'Default editor for all sites', 'classic-editor' ); ?></th>
 				<td>
 					<p>
 						<input type="radio" name="classic-editor-replace" id="classic-editor-classic" value="classic"<?php if ( $editor !== 'block' ) echo ' checked'; ?> />
-						<label for="classic-editor-classic"><?php echo esc_html_x( 'Classic Editor', 'Editor Name', 'classic-editor' ); ?></label>
+						<label for="classic-editor-classic"><?php echo _ex( 'Classic Editor', 'Editor Name', 'classic-editor' ); ?></label>
 					</p>
 					<p>
 						<input type="radio" name="classic-editor-replace" id="classic-editor-block" value="block"<?php if ( $editor === 'block' ) echo ' checked'; ?> />
-						<label for="classic-editor-block"><?php echo esc_html_x( 'Block editor', 'Editor Name', 'classic-editor' ); ?></label>
+						<label for="classic-editor-block"><?php echo _ex( 'Block editor', 'Editor Name', 'classic-editor' ); ?></label>
 					</p>
 				</td>
 			</tr>
 			<tr>
-				<th scope="row"><?php esc_html_e( 'Change settings', 'classic-editor' ); ?></th>
+				<th scope="row"><?php _e( 'Change settings', 'classic-editor' ); ?></th>
 				<td>
 					<input type="checkbox" name="classic-editor-allow-sites" id="classic-editor-allow-sites" value="allow"<?php if ( $is_checked ) echo ' checked'; ?>>
-					<label for="classic-editor-allow-sites"><?php esc_html_e( 'Allow site admins to change settings', 'classic-editor' ); ?></label>
-					<p class="description"><?php esc_html_e( 'By default the block editor is replaced with the classic editor and users cannot switch editors.', 'classic-editor' ); ?></p>
+					<label for="classic-editor-allow-sites"><?php _e( 'Allow site admins to change settings', 'classic-editor' ); ?></label>
+					<p class="description"><?php _e( 'By default the block editor is replaced with the classic editor and users cannot switch editors.', 'classic-editor' ); ?></p>
 				</td>
 			</tr>
 		</table>
@@ -660,7 +660,7 @@ class Classic_Editor {
 
 		?>
 		<p style="margin: 1em 0;">
-			<a href="<?php echo esc_url( $edit_url ); ?>"><?php esc_html_e( 'Switch to block editor', 'classic-editor' ); ?></a>
+			<a href="<?php echo esc_url( $edit_url ); ?>"><?php _e( 'Switch to block editor', 'classic-editor' ); ?></a>
 		</p>
 		<?php
 	}

--- a/classic-editor.php
+++ b/classic-editor.php
@@ -110,7 +110,7 @@ class Classic_Editor {
 					self::remove_gutenberg_hooks();
 				}
 			} else {
-				// `$settings['editor'] === 'block'`, nothing to do :)
+				// The $settings['editor'] value is 'block' so there is nothing to do.
 				return;
 			}
 		}
@@ -178,6 +178,7 @@ class Classic_Editor {
 		remove_action( 'admin_enqueue_scripts', 'gutenberg_check_if_classic_needs_warning_about_blocks' );
 		remove_filter( 'register_post_type_args', 'gutenberg_filter_post_type_labels' );
 
+		// phpcs:disable Squiz.PHP.CommentedOutCode.Found
 		// Keep
 		// remove_filter( 'wp_kses_allowed_html', 'gutenberg_kses_allowedtags', 10, 2 ); // not needed in 5.0
 		// remove_filter( 'bulk_actions-edit-wp_block', 'gutenberg_block_bulk_actions' );
@@ -188,6 +189,7 @@ class Classic_Editor {
 		// Continue to manage wpautop for posts that were edited in Gutenberg.
 		// remove_filter( 'wp_editor_settings', 'gutenberg_disable_editor_settings_wpautop' );
 		// remove_filter( 'the_content', 'gutenberg_wpautop', 8 );
+		// phpcs:enable Squiz.PHP.CommentedOutCode.Found
 
 	}
 
@@ -256,7 +258,7 @@ class Classic_Editor {
 			if ( $option === 'block' || $option === 'no-replace' ) {
 				$editor = 'block';
 			} else {
-				// empty( $option ) || $option === 'classic' || $option === 'replace'.
+				// The $option variable is either empty, set to classic, or set to replace.
 				$editor = 'classic';
 			}
 		}
@@ -287,7 +289,7 @@ class Classic_Editor {
 		if ( $post_id ) {
 			$settings = self::get_settings();
 
-			if ( $settings['allow-users'] && ! isset( $_GET['classic-editor__forget'] ) ) {
+			if ( $settings['allow-users'] && ! isset( $_GET['classic-editor__forget'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				$which = get_post_meta( $post_id, 'classic-editor-remember', true );
 
 				if ( $which ) {
@@ -303,7 +305,7 @@ class Classic_Editor {
 			}
 		}
 
-		if ( isset( $_GET['classic-editor'] ) ) {
+		if ( isset( $_GET['classic-editor'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return true;
 		}
 
@@ -314,6 +316,7 @@ class Classic_Editor {
 	 * Get the edited post ID (early) when loading the Edit Post screen.
 	 */
 	private static function get_edited_post_id() {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if (
 			! empty( $_GET['post'] ) &&
 			! empty( $_GET['action'] ) &&
@@ -323,6 +326,7 @@ class Classic_Editor {
 		) {
 			return (int) $_GET['post']; // post_ID
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		return 0;
 	}
@@ -361,7 +365,7 @@ class Classic_Editor {
 		if (
 			isset( $_POST['classic-editor-user-settings'] ) &&
 			isset( $_POST['classic-editor-replace'] ) &&
-			wp_verify_nonce( $_POST['classic-editor-user-settings'], 'allow-user-settings' )
+			wp_verify_nonce( $_POST['classic-editor-user-settings'], 'allow-user-settings' ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		) {
 			$user_id = (int) $user_id;
 
@@ -369,7 +373,7 @@ class Classic_Editor {
 				return;
 			}
 
-			$editor = self::validate_option_editor( $_POST['classic-editor-replace'] );
+			$editor = self::validate_option_editor( $_POST['classic-editor-replace'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			update_user_option( $user_id, 'classic-editor-settings', $editor );
 		}
 	}
@@ -400,11 +404,11 @@ class Classic_Editor {
 		<div class="classic-editor-options">
 			<p>
 				<input type="radio" name="classic-editor-replace" id="classic-editor-classic" value="classic"<?php if ( $settings['editor'] === 'classic' ) echo ' checked'; ?> />
-				<label for="classic-editor-classic"><?php _ex( 'Classic editor', 'Editor Name', 'classic-editor' ); ?></label>
+				<label for="classic-editor-classic"><?php echo esc_html_x( 'Classic editor', 'Editor Name', 'classic-editor' ); ?></label>
 			</p>
 			<p>
 				<input type="radio" name="classic-editor-replace" id="classic-editor-block" value="block"<?php if ( $settings['editor'] !== 'classic' ) echo ' checked'; ?> />
-				<label for="classic-editor-block"><?php _ex( 'Block editor', 'Editor Name', 'classic-editor' ); ?></label>
+				<label for="classic-editor-block"><?php echo esc_html_x( 'Block editor', 'Editor Name', 'classic-editor' ); ?></label>
 			</p>
 		</div>
 		<script>
@@ -424,11 +428,11 @@ class Classic_Editor {
 		<div class="classic-editor-options">
 			<p>
 				<input type="radio" name="classic-editor-allow-users" id="classic-editor-allow" value="allow"<?php if ( $settings['allow-users'] ) echo ' checked'; ?> />
-				<label for="classic-editor-allow"><?php _e( 'Yes', 'classic-editor' ); ?></label>
+				<label for="classic-editor-allow"><?php esc_html_e( 'Yes', 'classic-editor' ); ?></label>
 			</p>
 			<p>
 				<input type="radio" name="classic-editor-allow-users" id="classic-editor-disallow" value="disallow"<?php if ( ! $settings['allow-users'] ) echo ' checked'; ?> />
-				<label for="classic-editor-disallow"><?php _e( 'No', 'classic-editor' ); ?></label>
+				<label for="classic-editor-disallow"><?php esc_html_e( 'No', 'classic-editor' ); ?></label>
 			</p>
 		</div>
 		<?php
@@ -453,7 +457,7 @@ class Classic_Editor {
 		?>
 		<table class="form-table">
 			<tr class="classic-editor-user-options">
-				<th scope="row"><?php _e( 'Default Editor', 'classic-editor' ); ?></th>
+				<th scope="row"><?php esc_html_e( 'Default Editor', 'classic-editor' ); ?></th>
 				<td>
 				<?php wp_nonce_field( 'allow-user-settings', 'classic-editor-user-settings' ); ?>
 				<?php self::settings_1(); ?>
@@ -469,28 +473,28 @@ class Classic_Editor {
 		$is_checked = ( get_network_option( null, 'classic-editor-allow-sites' ) === 'allow' );
 
 		?>
-		<h2 id="classic-editor-options"><?php _e( 'Editor Settings', 'classic-editor' ); ?></h2>
+		<h2 id="classic-editor-options"><?php esc_html_e( 'Editor Settings', 'classic-editor' ); ?></h2>
 		<table class="form-table">
 			<?php wp_nonce_field( 'allow-site-admin-settings', 'classic-editor-network-settings' ); ?>
 			<tr>
-				<th scope="row"><?php _e( 'Default editor for all sites', 'classic-editor' ); ?></th>
+				<th scope="row"><?php esc_html_e( 'Default editor for all sites', 'classic-editor' ); ?></th>
 				<td>
 					<p>
 						<input type="radio" name="classic-editor-replace" id="classic-editor-classic" value="classic"<?php if ( $editor !== 'block' ) echo ' checked'; ?> />
-						<label for="classic-editor-classic"><?php _ex( 'Classic editor', 'Editor Name', 'classic-editor' ); ?></label>
+						<label for="classic-editor-classic"><?php echo esc_html_x( 'Classic Editor', 'Editor Name', 'classic-editor' ); ?></label>
 					</p>
 					<p>
 						<input type="radio" name="classic-editor-replace" id="classic-editor-block" value="block"<?php if ( $editor === 'block' ) echo ' checked'; ?> />
-						<label for="classic-editor-block"><?php _ex( 'Block editor', 'Editor Name', 'classic-editor' ); ?></label>
+						<label for="classic-editor-block"><?php echo esc_html_x( 'Block editor', 'Editor Name', 'classic-editor' ); ?></label>
 					</p>
 				</td>
 			</tr>
 			<tr>
-				<th scope="row"><?php _e( 'Change settings', 'classic-editor' ); ?></th>
+				<th scope="row"><?php esc_html_e( 'Change settings', 'classic-editor' ); ?></th>
 				<td>
 					<input type="checkbox" name="classic-editor-allow-sites" id="classic-editor-allow-sites" value="allow"<?php if ( $is_checked ) echo ' checked'; ?>>
-					<label for="classic-editor-allow-sites"><?php _e( 'Allow site admins to change settings', 'classic-editor' ); ?></label>
-					<p class="description"><?php _e( 'By default the block editor is replaced with the classic editor and users cannot switch editors.', 'classic-editor' ); ?></p>
+					<label for="classic-editor-allow-sites"><?php esc_html_e( 'Allow site admins to change settings', 'classic-editor' ); ?></label>
+					<p class="description"><?php esc_html_e( 'By default the block editor is replaced with the classic editor and users cannot switch editors.', 'classic-editor' ); ?></p>
 				</td>
 			</tr>
 		</table>
@@ -501,7 +505,7 @@ class Classic_Editor {
 		if (
 			isset( $_POST['classic-editor-network-settings'] ) &&
 			current_user_can( 'manage_network_options' ) &&
-			wp_verify_nonce( $_POST['classic-editor-network-settings'], 'allow-site-admin-settings' )
+			wp_verify_nonce( $_POST['classic-editor-network-settings'], 'allow-site-admin-settings' ) // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		) {
 			if ( isset( $_POST['classic-editor-replace'] ) && $_POST['classic-editor-replace'] === 'block' ) {
 				update_network_option( null, 'classic-editor-replace', 'block' );
@@ -578,6 +582,7 @@ class Classic_Editor {
 
 		// Open the default editor when no $post and for "Add New" links,
 		// or the alternate editor when the user is switching editors.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( empty( $post->ID ) || $post->post_status === 'auto-draft' ) {
 			if (
 				( $settings['editor'] === 'classic' && ! isset( $_GET['classic-editor__forget'] ) ) ||  // Add New
@@ -588,6 +593,7 @@ class Classic_Editor {
 		} elseif ( self::is_classic( $post->ID ) ) {
 			$use_block_editor = false;
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		// Enforce the editor if set by plugins.
 		if ( $use_block_editor && ! $editors['block_editor'] ) {
@@ -604,8 +610,8 @@ class Classic_Editor {
 	 */
 	public static function redirect_location( $location ) {
 		if (
-			isset( $_REQUEST['classic-editor'] ) ||
-			( isset( $_POST['_wp_http_referer'] ) && strpos( $_POST['_wp_http_referer'], '&classic-editor' ) !== false )
+			isset( $_REQUEST['classic-editor'] ) || // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			( isset( $_POST['_wp_http_referer'] ) && strpos( $_POST['_wp_http_referer'], '&classic-editor' ) !== false ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Missing
 		) {
 			$location = add_query_arg( 'classic-editor', '', $location );
 		}
@@ -619,7 +625,7 @@ class Classic_Editor {
 	public static function get_edit_post_link( $url ) {
 		$settings = self::get_settings();
 
-		if ( isset( $_REQUEST['classic-editor'] ) || $settings['editor'] === 'classic' ) {
+		if ( isset( $_REQUEST['classic-editor'] ) || $settings['editor'] === 'classic' ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$url = add_query_arg( 'classic-editor', '', $url );
 		}
 
@@ -654,7 +660,7 @@ class Classic_Editor {
 
 		?>
 		<p style="margin: 1em 0;">
-			<a href="<?php echo esc_url( $edit_url ); ?>"><?php _e( 'Switch to block editor', 'classic-editor' ); ?></a>
+			<a href="<?php echo esc_url( $edit_url ); ?>"><?php esc_html_e( 'Switch to block editor', 'classic-editor' ); ?></a>
 		</p>
 		<?php
 	}


### PR DESCRIPTION
This adds some wpcs fixes that were flagged in VIP GO. 

Much of this is just adding some ignore flags as the found issues were not applicable. For example, several instances were found indicating variables should be sanitized, but the usage didn't result in outputting the variable, instead they are checked against specific values to result in boolean. Other cases were recommendations for nonce verification where it wouldn't necessarily be prudent.

There are some cases where commented lines had a form of code to indicate the conditional state. Those were updated to explain the state instead of using code in order to address a flag that the line is at least 50% valid code.

Lines 182-190 are actual code with a comment to "keep."

I don't know the history there so I followed the comment and disabled the sniff for those lines. However, if the goal is to just know that code, it might make more sense to either move it to documentation or remove it and let git history to its' job instead of maintaining commented out code in the project.

The remaining issues are uses of `_e()` and `_ex()`. These are outputting unescaped strings. This could be exploited via a translation based hack and pose an actual security risk. 

These are updated to use `esc_html_e()` and `echo esc_html_ex()` respectively. 

If nothing else, I can do a PR that only addresses these as it is a more urgent security fix. 