### PR TITLE
Updates for WordPress 5.9

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -13,7 +13,7 @@
  * Text Domain: classic-editor
  * Domain Path: /languages
  * Requires at least: 4.9
- * Tested up to: 5.8
+ * Tested up to: 5.9
  * Requires PHP: 5.2.4
  *
  * This program is free software; you can redistribute it and/or modify it under the terms of the GNU

--- a/readme.txt
+++ b/readme.txt
@@ -108,14 +108,14 @@ Initial release.
 
 = Default settings =
 
-When activated this plugin will restore the previous ("classic") WordPress editor and hide the new block editor ("Gutenberg").
+When activated and when using a classic (non-block) theme, this plugin will restore the previous ("classic") WordPress editor and hide the new block editor ("Gutenberg").
 These settings can be changed at the Settings => Writing screen.
 
 = Default settings for network installation =
 
 There are two options:
 
-* When network-activated this plugin will set the classic editor as default and prevent site administrators and users from changing editors.
+* When network-activated and when using a classic (non-block) theme, this plugin will set the classic editor as default and prevent site administrators and users from changing editors.
 The settings can be changed and default network-wide editor can be selected on the Network Settings screen.
 * When not network-activated each site administrator will be able to activate the plugin and choose options for their users.
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: wordpressdotorg, azaozz, melchoyce, chanthaboune, alexislloyd, pento, youknowriad, desrosj, luciano-croce
 Tags: gutenberg, disable, disable gutenberg, editor, classic editor, block editor
 Requires at least: 4.9
-Tested up to: 5.8
-Stable tag: 1.6.2
+Tested up to: 5.9
+Stable tag: 1.7.0
 Requires PHP: 5.2.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -28,6 +28,9 @@ In addition, the Classic Editor plugin includes several filters that let other p
 By default, this plugin hides all functionality available in the new block editor ("Gutenberg").
 
 == Changelog ==
+
+= 1.7.0 =
+* Updated for WordPress 5.9.
 
 = 1.6.2 =
 * Fixed bug that was preventing saving of the last used editor.
@@ -128,3 +131,7 @@ It is in the main block editor menu, see this [screenshot](https://ps.w.org/clas
 5. Link to switch to the classic editor while editing a post in the block editor. Visible when the users are allowed to switch editors.
 6. Network settings to select the default editor for the network and allow site admins to change it.
 7. The "Switch to classic editor" link.
+
+= Does this work with full site editing and block themes? =
+
+No, as block themes rely on blocks. [See Block themes article](https://wordpress.org/support/article/block-themes/) for more information.


### PR DESCRIPTION
Fixes https://github.com/WordPress/classic-editor/issues/175

* Raises "Tested up to" for 5.9.
* Adds the question in FAQs if this works on block themes with a link to the Block Theme article for more information.