### PR TITLE
Remove Gutenberg SVG's

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -197,6 +197,16 @@ class Classic_Editor {
 
 	}
 
+	/**
+	 * Runs on hook after_setup_theme
+	 *
+	 * @return void
+	 */
+	public static function remove_after_setup_theme_hook() {
+		remove_action( 'wp_body_open', 'wp_global_styles_render_svg_filters' );
+		remove_action( 'in_admin_header', 'wp_global_styles_render_svg_filters' );
+	}
+
 	private static function get_settings( $refresh = 'no' ) {
 		/**
 		 * Can be used to override the plugin's settings. Always hides the settings UI when used (as users cannot change the settings).
@@ -968,5 +978,7 @@ class Classic_Editor {
 }
 
 add_action( 'plugins_loaded', array( 'Classic_Editor', 'init_actions' ) );
+
+add_action('after_setup_theme', 'Classic_Editor::remove_after_setup_theme_hook', 10, 0);
 
 endif;

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Classic Editor ===
-Contributors: wordpressdotorg, azaozz, melchoyce, chanthaboune, alexislloyd, pento, youknowriad, desrosj, luciano-croce
+Contributors: wordpressdotorg, azaozz, melchoyce, chanthaboune, alexislloyd, pento, youknowriad, desrosj, luciano-croce, emilwibe
 Tags: gutenberg, disable, disable gutenberg, editor, classic editor, block editor
 Requires at least: 4.9
 Tested up to: 5.9


### PR DESCRIPTION
This pull request adds a static function to be used with the after_theme_setup hook. Since WP 5.9 WP is outputting static SVG tags that are being used for Gutenbergs Duotone feature.

I don't know if this has to be bumped up in version or something...

Kind regards

EW