### PR TITLE
Added missing default param value

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -207,7 +207,7 @@ class Classic_Editor {
 		 *   'editor' => 'classic', // Accepted values: 'classic', 'block'.
 		 *   'allow-users' => false,
 		 *
-		 * @param boolean To override the settings return an array with the above keys.
+		 * @param boolean To override the settings return an array with the above keys. Default false.
 		 */
 		$settings = apply_filters( 'classic_editor_plugin_settings', false );
 


### PR DESCRIPTION
I added "Default false" to the @param tag to clarify to developers that this parameter is optional and its default value is false.