### PR TITLE
Updates for 6.5

### DIFF
--- a/assets/blueprints/blueprint.json
+++ b/assets/blueprints/blueprint.json
@@ -1,0 +1,23 @@
+{
+    "landingPage": "/wp-admin/post-new.php",
+    "features": {
+        "networking": true
+    },
+    "steps": [
+        {
+            "step": "login",
+            "username": "admin",
+            "password": "password"
+        },
+        {
+            "step": "installPlugin",
+            "pluginZipFile": {
+                "resource": "wordpress.org/plugins",
+                "slug": "classic-editor"
+            },
+            "options": {
+                "activate": true
+            }
+        }
+    ]
+}

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 === Classic Editor ===
-Contributors: wordpressdotorg, azaozz, melchoyce, chanthaboune, alexislloyd, pento, youknowriad, desrosj, luciano-croce
+Contributors: wordpressdotorg, azaozz, melchoyce, chanthaboune, alexislloyd, pento, youknowriad, desrosj, luciano-croce, ironprogrammer
 Tags: gutenberg, disable, disable gutenberg, editor, classic editor, block editor
 Requires at least: 4.9
 Tested up to: 6.5

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg, azaozz, melchoyce, chanthaboune, alexislloyd, pento, youknowriad, desrosj, luciano-croce
 Tags: gutenberg, disable, disable gutenberg, editor, classic editor, block editor
 Requires at least: 4.9
-Tested up to: 6.2
+Tested up to: 6.5
 Stable tag: 1.6.3
 Requires PHP: 5.2.4
 License: GPLv2 or later


### PR DESCRIPTION
Fixes #212:
- Bumps plugin's "tested up to" version to 6.5.
- Adds a blueprint for the plugin directory's live preview feature. Blueprint loads plugin and navigates to the New Post screen where classic editor should be active. (This feature will need to be tested and enabled by a plugin committer after this PR is approved/merged.)

[Click here for a Playground test link that simulates what the plugin preview link should do.](https://playground.wordpress.net/?plugin=classic-editor&url=/wp-admin/post-new.php)