### PR TITLE
Add admin notice for live preview blueprint

### DIFF
--- a/assets/blueprints/blueprint.json
+++ b/assets/blueprints/blueprint.json
@@ -18,6 +18,11 @@
             "options": {
                 "activate": true
             }
+        },
+        {
+            "step": "writeFile",
+            "path": "/wordpress/wp-content/mu-plugins/playground-notice.php",
+            "data": "<?php add_action( 'admin_notices', function() { echo '<div class=\"notice notice-info is-dismissible\"><p>This is a live preview of <strong>Classic Editor</strong>, powered by <a href=\"https://wordpress.org/playground/\" target=\"_blank\">WordPress Playground</a>.</p></div>'; } );"
         }
     ]
 }


### PR DESCRIPTION
This PR adds an admin notice to the live preview blueprint that highlights/reminds users that they are viewing a preview, and calls out Playground. The notice appears like this:

<img width="506" alt="Admin notice for Classic Editor running in live preview." src="https://github.com/WordPress/classic-editor/assets/824344/6d0f41db-0b7a-424d-b5ee-dd6a3bf744a0">

## Testing
To test this plugin's preview blueprint, go to the [Blueprint Builder tool](https://playground.wordpress.net/builder/builder.html), replace the default JSON with this plugin's `blueprint.json`, and click Run It.