### PR TITLE
Readme updates for 1.6.4 release

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpressdotorg, azaozz, melchoyce, chanthaboune, alexislloyd, pen
 Tags: gutenberg, disable, disable gutenberg, editor, classic editor, block editor
 Requires at least: 4.9
 Tested up to: 6.5
-Stable tag: 1.6.3
+Stable tag: 1.6.4
 Requires PHP: 5.2.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -28,6 +28,9 @@ In addition, the Classic Editor plugin includes several filters that let other p
 By default, this plugin hides all functionality available in the new block editor ("Gutenberg").
 
 == Changelog ==
+
+= 1.6.4 =
+* Added support for administrators to choose the default editor for other users.
 
 = 1.6.3 =
 * Added some WPCS fixes, props NicktheGeek on GitHub.

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg, azaozz, melchoyce, chanthaboune, alexislloyd, pento, youknowriad, desrosj, luciano-croce, ironprogrammer
 Tags: gutenberg, disable, disable gutenberg, editor, classic editor, block editor
 Requires at least: 4.9
-Tested up to: 6.5
+Tested up to: 6.6
 Stable tag: 1.6.4
 Requires PHP: 5.2.4
 License: GPLv2 or later


### PR DESCRIPTION
Updated changelog for recent updates, and coordinated `Tested up to` version for the [WordPress 6.6 release](https://make.wordpress.org/core/6-6/).