### PR TITLE
Use `script_loader_src` hook for temporary Categories fix

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpressdotorg, azaozz, melchoyce, chanthaboune, alexislloyd, pen
 Tags: classic editor, block editor, editor, gutenberg
 Requires at least: 4.9
 Tested up to: 6.7
-Stable tag: 1.6.6
+Stable tag: 1.6.7
 Requires PHP: 5.2.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -28,6 +28,9 @@ In addition, the Classic Editor plugin includes several filters that let other p
 By default, this plugin hides all functionality available in the new block editor ("Gutenberg").
 
 == Changelog ==
+
+= 1.6.7 =
+* Fixed loading of script translations when post.js is replaced in WordPress 6.7.1.
 
 = 1.6.6 =
 * Added fix for selecting/deselecting multiple unwanted categories in WordPress 6.7.1 when clicking on a category checkbox on the old Edit Post screen.


### PR DESCRIPTION
Fixes #222

Maintains the original `post` handle for translations, but changes the `src` to the plugin's file.