### PR TITLE
Add JavaScript to conditionally disable the publish button in the classic Editor

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -144,6 +144,48 @@ class Classic_Editor {
 			remove_filter( 'display_post_states', 'gutenberg_add_gutenberg_post_state' );
 			remove_action( 'edit_form_top', 'gutenberg_remember_classic_editor_when_saving_posts' );
 		}
+		add_action( 'admin_print_footer_scripts', array( __CLASS__, 'conditionally_disable_publish_button_classic_editor' ) );
+	}
+
+	public static function conditionally_disable_publish_button_classic_editor() {
+		$screen = get_current_screen();
+		if ( ! in_array( $screen->base, [ 'post' ], true ) ) {
+			return;
+		}
+		if ( function_exists( 'use_block_editor_for_post_type' ) && use_block_editor_for_post_type( $screen->post_type ) ) {
+			return;
+		}
+		?>
+		<script type="text/javascript">
+		jQuery( document ).ready( function( $ ) {
+			var $publishBtn = $( '#publish' );
+			$publishBtn.attr( 'disabled', true );
+
+			function togglePublishButton() {
+				var title = $( '#title' ).val().trim();
+				var content = '';
+
+				if ( typeof tinyMCE !== 'undefined' && tinyMCE.activeEditor && !tinyMCE.activeEditor.isHidden() ) {
+					content = tinyMCE.activeEditor.getContent( { format: 'text' } ).trim();
+				} else {
+					content = $( '#content' ).val().trim();
+				}
+
+				if ( title === '' && content === '' ) {
+					$publishBtn.attr( 'disabled', true );
+				} else {
+					$publishBtn.attr( 'disabled', false );
+				}
+			}
+			$( '#title, #content' ).on( 'input keyup change', togglePublishButton );
+			if ( typeof tinyMCE !== 'undefined' ) {
+				tinymce.on( 'AddEditor', function(e) {
+					e.editor.on( 'keyup change', togglePublishButton );
+				} );
+			}
+		});
+		</script>
+		<?php
 	}
 
 	public static function remove_gutenberg_hooks( $remove = 'all' ) {


### PR DESCRIPTION
This PR solves : https://core.trac.wordpress.org/ticket/62769

### Summary
This PR adds logic to disable the "Publish" button in the Classic Editor interface when both the post title and content fields are empty. The button is automatically re-enabled once either field has valid input.

### Key Features
#### Applies to:

post, page, and any custom post types (CPTs) using the Classic Editor.

Skips block editor (Gutenberg) screens using use_block_editor_for_post_type().

Prevents users from accidentally publishing completely empty content.

Improves UX by disabling the button immediately on page load (avoids flicker).

Listens to title input and content changes (including TinyMCE events).

### Technical Details
Hook used: admin_print_footer_scripts

Detects screen type using get_current_screen().

Disables #publish button early and conditionally re-enables it.

TinyMCE support: content changes tracked even within WYSIWYG editor.

### How to Test
Open the Classic Editor for any post, page, or CPT.

Ensure both the title and content fields are empty.

Observe that the "Publish" button is disabled on load.

Add either a title or content — the button should become enabled.

Clear both fields — the button should disable again.

### Notes
This change is purely front-end (JS in admin), ensuring a better editorial workflow. It does not add server-side validation — users with direct access (e.g., via REST API or browser overrides) can still submit empty posts.