### PR TITLE
Bump tested up to for WP 7.0.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg, azaozz, melchoyce, chanthaboune, alexislloyd, pento, youknowriad, desrosj, luciano-croce, ironprogrammer
 Tags: classic editor, block editor, editor, gutenberg
 Requires at least: 4.9
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag: 1.6.7
 Requires PHP: 5.2.4
 License: GPLv2 or later


### PR DESCRIPTION
## Bump tested up to for WP 7.0.

Verified locally against a stock WordPress 7.0 install (`wordpress:7.0-apache` / PHP 8.3 + `mysql:8.0`) with `WP_DEBUG` and `SCRIPT_DEBUG` on. Plugin source under test is HEAD of `trunk` (released 1.6.7).

### What I exercised

- **Activation**: `wp plugin activate classic-editor` was successful. No PHP notices, warnings, or deprecations in `wp-content/debug.log` (which was never created).
- **Default settings (classic editor, no user switching)**: `use_block_editor_for_post_type` returns false, so the classic editor is used.
- **`allow-users=allow`**: `use_block_editor_for_post` resolves through `choose_editor` without error and the classic editor is used for the test post.
- **`editor=block` (plugin steps aside)**: `use_block_editor_for_post_type` returns true, so the block editor is used and the plugin stays out of the path.
- **Lifecycle**: deactivate, then reactivate, then invoke `Classic_Editor::uninstall()` directly via `wp eval`. Both `classic-editor-replace` and `classic-editor-allow-users` options are removed afterwards.
- **Browser-side (Playwright, Chromium)**:
  - `/wp-admin/post-new.php`: the TinyMCE iframe (`#content_ifr`, `body#tinymce`) initializes, accepts input, and Save Draft round-trips the title. Zero `pageerror` events and zero `console.error` calls.
  - Categories postbox on the Edit Post screen: seeded four categories, clicked one at a time, and asserted that exactly one checkbox's state changed per click. The WP 6.7.1 multi-toggle regression that the plugin's `replace_post_js_2` shim was built to paper over is not present on WP 7.0.

### What I did NOT cover

Single PHP version (8.3), single DB (MySQL 8.0), single-site only, default active theme. Multisite, block-theme, MariaDB, and the full PHP 7.2 through 8.4 matrix were out of scope here.

### Note

This PR is intentionally narrow: just the `Tested up to:` line in `readme.txt`. The related cleanup of the now-unreachable 6.7.1 `replace_post_js_2` shim and the corresponding `Requires at least` bump are submitted as a separate PR so each can be evaluated on its own merits.
