### PR TITLE
Fix `flex-wrap` issue in 7.0 release

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -5,7 +5,7 @@
  * Plugin Name: Classic Editor
  * Plugin URI:  https://wordpress.org/plugins/classic-editor/
  * Description: Enables the WordPress classic editor and the old-style Edit Post screen with TinyMCE, Meta Boxes, etc. Supports the older plugins that extend this screen.
- * Version:     1.6.7
+ * Version:     1.7.0
  * Author:      WordPress Contributors
  * Author URI:  https://github.com/WordPress/classic-editor/
  * License:     GPLv2 or later
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! defined( 'CLASSIC_EDITOR_VERSION' ) ) {
-	define( 'CLASSIC_EDITOR_VERSION', '1.6.7' );
+	define( 'CLASSIC_EDITOR_VERSION', '1.7.0' );
 }
 
 if ( ! class_exists( 'Classic_Editor' ) ) :

--- a/classic-editor.php
+++ b/classic-editor.php
@@ -80,6 +80,16 @@ class Classic_Editor {
 			add_filter( 'script_loader_src', array( __CLASS__, 'replace_post_js_2' ), 11, 2 );
 		}
 
+		/*
+		 * 7.0 applied a fresh coat of paint to the admin area of WordPress. An unintended side effect was that
+		 * buttons are crowded in the Publish meta box.
+		 *
+		 * See https://core.trac.wordpress.org/ticket/65286.
+		 */
+		if ( version_compare( $wp_version, '7.0', '>=' ) ) {
+			wp_enqueue_style( 'classic-editor-hotfix-7-0', plugins_url( 'css/hotfix-7-0.css', __FILE__ ), array(), CLASSIC_EDITOR_VERSION );
+		}
+
 		if ( ! $block_editor && ! $gutenberg  ) {
 			return;
 		}

--- a/classic-editor.php
+++ b/classic-editor.php
@@ -27,6 +27,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Invalid request.' );
 }
 
+if ( ! defined( 'CLASSIC_EDITOR_VERSION' ) ) {
+	define( 'CLASSIC_EDITOR_VERSION', '1.6.7' );
+}
+
 if ( ! class_exists( 'Classic_Editor' ) ) :
 class Classic_Editor {
 	private static $settings;
@@ -709,7 +713,7 @@ class Classic_Editor {
 			'classic-editor-plugin',
 			plugins_url( 'js/block-editor-plugin.js', __FILE__ ),
 			array( 'wp-element', 'wp-components', 'lodash' ),
-			'1.4',
+			CLASSIC_EDITOR_VERSION,
 			true
 		);
 

--- a/classic-editor.php
+++ b/classic-editor.php
@@ -81,7 +81,7 @@ class Classic_Editor {
 		}
 
         if ( version_compare( $wp_version, '7.0', '>=' ) ) {
-            add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_70_hotfix' ) );
+            add_action( 'admin_print_styles', array( __CLASS__, 'print_70_publishing_actions_hotfix' ) );
         }
 
 		if ( ! $block_editor && ! $gutenberg  ) {
@@ -1042,15 +1042,20 @@ class Classic_Editor {
      * buttons are crowded within the Publish meta box.
      *
      * See https://core.trac.wordpress.org/ticket/65286.
-     *
-     * @param $hook_suffix string The current admin page.
      */
-    public static function enqueue_70_hotfix( $hook_suffix ) {
+    public static function print_70_publishing_actions_hotfix() {
+        global $hook_suffix;
+
         if ( ! in_array( $hook_suffix, array( 'post.php', 'post-new.php' ) ) ) {
             return;
         }
-
-        wp_enqueue_style( 'classic-editor-hotfix-7-0', plugins_url( 'css/hotfix-7-0.css', __FILE__ ), array(), CLASSIC_EDITOR_VERSION );
+        ?>
+        <style>
+            #major-publishing-actions {
+                flex-wrap: wrap;
+            }
+        </style>
+        <?php
     }
 }
 

--- a/classic-editor.php
+++ b/classic-editor.php
@@ -80,15 +80,9 @@ class Classic_Editor {
 			add_filter( 'script_loader_src', array( __CLASS__, 'replace_post_js_2' ), 11, 2 );
 		}
 
-		/*
-		 * 7.0 applied a fresh coat of paint to the admin area of WordPress. An unintended side effect was that
-		 * buttons are crowded in the Publish meta box.
-		 *
-		 * See https://core.trac.wordpress.org/ticket/65286.
-		 */
-		if ( version_compare( $wp_version, '7.0', '>=' ) ) {
-			wp_enqueue_style( 'classic-editor-hotfix-7-0', plugins_url( 'css/hotfix-7-0.css', __FILE__ ), array(), CLASSIC_EDITOR_VERSION );
-		}
+        if ( version_compare( $wp_version, '7.0', '>=' ) ) {
+            add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_70_hotfix' ) );
+        }
 
 		if ( ! $block_editor && ! $gutenberg  ) {
 			return;
@@ -1040,6 +1034,24 @@ class Classic_Editor {
 
 		return $src;
 	}
+
+    /**
+     * Enqueues styles to address crowded buttons in WordPress 7.0.
+     *
+     * 7.0 applied a fresh coat of paint to the admin area of WordPress. An unintended side effect was that
+     * buttons are crowded within the Publish meta box.
+     *
+     * See https://core.trac.wordpress.org/ticket/65286.
+     *
+     * @param $hook_suffix string The current admin page.
+     */
+    public static function enqueue_70_hotfix( $hook_suffix ) {
+        if ( ! in_array( $hook_suffix, array( 'post.php', 'post-new.php' ) ) ) {
+            return;
+        }
+
+        wp_enqueue_style( 'classic-editor-hotfix-7-0', plugins_url( 'css/hotfix-7-0.css', __FILE__ ), array(), CLASSIC_EDITOR_VERSION );
+    }
 }
 
 add_action( 'plugins_loaded', array( 'Classic_Editor', 'init_actions' ) );

--- a/css/hotfix-7-0.css
+++ b/css/hotfix-7-0.css
@@ -1,0 +1,3 @@
+#major-publishing-actions {
+	flex-wrap: wrap;
+}

--- a/css/hotfix-7-0.css
+++ b/css/hotfix-7-0.css
@@ -1,3 +1,0 @@
-#major-publishing-actions {
-	flex-wrap: wrap;
-}

--- a/readme.txt
+++ b/readme.txt
@@ -29,6 +29,9 @@ By default, this plugin hides all functionality available in the new block edito
 
 == Changelog ==
 
+= 1.7.0 =
+* Added a hotfix for publishing actions in WordPress 7.0.
+
 = 1.6.7 =
 * Fixed loading of script translations when post.js is replaced in WordPress 6.7.1.
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpressdotorg, azaozz, melchoyce, chanthaboune, alexislloyd, pen
 Tags: classic editor, block editor, editor, gutenberg
 Requires at least: 4.9
 Tested up to: 6.9
-Stable tag: 1.6.7
+Stable tag: 1.7.0
 Requires PHP: 5.2.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
This addresses an issue in the WordPress 7.0 release where elements in `#major-publishing-actions` are squished.

Since the issue is only present when using the Classic Editor and is happening for multiple plugins, this should just be fixed here until WordPress 7.0.1 is released.

See Core-65286.