### PR TITLE
[PCP] Phase 1: wp_function_not_compatible_with_requires_wp

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -1027,7 +1027,11 @@ class Classic_Editor {
 	 */
 	public static function replace_post_js_2( $src, $handle ) {
 		if ( 'post' === $handle && is_string( $src ) && false === strpos( $src, 'ver=62504-20241121' ) ) {
-			$suffix = wp_scripts_get_suffix();
+			if ( function_exists( 'wp_scripts_get_suffix' ) ) {
+				$suffix = wp_scripts_get_suffix();
+			} else {
+				$suffix = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+			}
 			$src    = plugins_url( 'scripts/', __FILE__ ) . "post{$suffix}.js";
 			$src    = add_query_arg( 'ver', '62504-20241121', $src );
 		}


### PR DESCRIPTION
## Fix: `wp_function_not_compatible_with_requires_wp` (lines 378, 758, 1030)

### Changes
- **Line 1030**: Wrap `wp_scripts_get_suffix()` in `function_exists()` guard with WP 4.9-compatible fallback using `defined('SCRIPT_DEBUG') && SCRIPT_DEBUG` to default to `.min` or empty string
- **Lines 378, 758**: Already have `function_exists()` guards — these are PCP false-positives (static analysis flags the call site even with runtime guards)

### Rule code
`wp_function_not_compatible_with_requires_wp`

### Verification
- PHPCS scan with `WordPress,PHPCompatibility` standards shows zero new violations
- CodeRabbit review: validated `SCRIPT_DEBUG` constant guard with `defined()` check
- Plugin declares `Requires at least: 4.9` — fallback preserves backward compat