### PR TITLE
[PCP] Phase 2: WordPress.WP.DeprecatedFunctions

### DIFF
--- a/classic-editor.php
+++ b/classic-editor.php
@@ -377,7 +377,7 @@ class Classic_Editor {
 		if ( function_exists( 'add_allowed_options' ) ) {
 			add_allowed_options( $allowed_options );
 		} else {
-			add_option_whitelist( $allowed_options );
+			add_option_whitelist( $allowed_options ); // phpcs:ignore WordPress.WP.DeprecatedFunctions -- 4.9 fallback, only called when add_allowed_options() doesn't exist
 		}
 
 		$heading_1 = __( 'Default editor for all users', 'classic-editor' );


### PR DESCRIPTION
## Fix: `WordPress.WP.DeprecatedFunctions.add_option_whitelistFound` (line 380)

### Changes
- **Line 380**: Add `// phpcs:ignore WordPress.WP.DeprecatedFunctions` annotation to `add_option_whitelist()` call, explaining this is an intentional WP 4.9 fallback — only invoked when `add_allowed_options()` doesn't exist

### Rule code
`WordPress.WP.DeprecatedFunctions.add_option_whitelistFound`

### Verification
- PHPCS scan with `WordPress` standard shows zero violations for `DeprecatedFunctions`